### PR TITLE
Eq params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Before any major/minor/patch is released all test units will be run to verify th
 - Patch class
 - Option class
 - Device classes
+- EQ class
 
 ## [3.3.0] - 2024-06-29
 

--- a/README.md
+++ b/README.md
@@ -321,11 +321,33 @@ The following strip.eq | bus.eq commands are available:
 - on: bool
 - ab: bool
 
+The following strip.eq | bus.eq methods are available:
+
+- Load($filepath) : string
+- Save($filepath) : string
+
 for example:
 
 ```powershell
 $vmr.strip[0].eq.on = $true
 $vmr.bus[0].eq.ab = $false
+```
+
+##### channel.cell
+
+The following eq.channel.cell commands are available:
+
+- on: bool
+- type: int, from 0 to 6
+- f: float, from 20.0 to 20000.0
+- gain: float, from -12.0 to 12.0
+- q: float, from 0.3 to 100.0
+
+for example:
+
+```powershell
+$vmr.strip[2].eq.channel[1].cell[4].type = 1
+$vmr.bus[5].eq.channel[6].cell[3].on = $false
 ```
 
 #### FadeTo | FadeBy

--- a/lib/Voicemeeter.psm1
+++ b/lib/Voicemeeter.psm1
@@ -5,6 +5,7 @@
 . $PSScriptRoot\iremote.ps1
 . $PSScriptRoot\arraymember.ps1
 . $PSScriptRoot\device.ps1
+. $PSScriptRoot\eq.ps1
 . $PSScriptRoot\strip.ps1
 . $PSScriptRoot\bus.ps1
 . $PSScriptRoot\macrobuttons.ps1

--- a/lib/bus.ps1
+++ b/lib/bus.ps1
@@ -84,7 +84,11 @@ class BusMode : IRemote {
 }
 
 class BusEq : Eq {
-    BusEq ([int]$index, [Object]$remote) : base ($index, $remote, 'Bus', $remote.kind.bus_ch) {
+    BusEq ([int]$index, [Object]$remote) : base ($index, $remote, 'Bus') {
+    }
+
+    [string] identifier () {
+        return 'Bus[' + $this.index + '].EQ'
     }
 }
 

--- a/lib/bus.ps1
+++ b/lib/bus.ps1
@@ -83,13 +83,8 @@ class BusMode : IRemote {
     }
 }
 
-class BusEq : IRemote {
-    BusEq ([int]$index, [Object]$remote) : base ($index, $remote) {
-        AddBoolMembers -PARAMS @('on', 'ab')
-    }
-
-    [string] identifier () {
-        return 'Bus[' + $this.index + '].EQ'
+class BusEq : Eq {
+    BusEq ([int]$index, [Object]$remote) : base ($index, $remote, 'Bus', $remote.kind.bus_ch) {
     }
 }
 

--- a/lib/eq.ps1
+++ b/lib/eq.ps1
@@ -1,0 +1,60 @@
+class Eq : IRemote {
+    [System.Collections.ArrayList]$channel
+    [string]$prefix
+    
+    Eq ([string]$prefix, [int]$chCount, [Object]$parent) : base ($parent.index, $parent.remote) {
+        AddBoolMembers -PARAMS @('on', 'ab')
+
+        $this.channel = @()
+        for ($ch = 0; $ch -lt $chCount; $ch++) {
+            $this.channel.Add([EqChannel]::new($ch, $this))
+        }
+
+        $this.prefix = $prefix
+    }
+
+    [void] Load ([string]$filename) {
+        $param = 'Command.Load{0}Eq[{1}]' -f $this.prefix, $this.index
+        $this.remote.Setter($param, $filename)
+    }
+
+    [void] Save ([string]$filename) {
+        $param = 'Command.Save{0}Eq[{1}]' -f $this.prefix, $this.index
+        $this.remote.Setter($param, $filename)
+    }
+}
+
+class EqChannel : IRemote {
+    [System.Collections.ArrayList]$cell
+    [string]$eqId
+    
+    EqChannel ([int]$index, [Object]$eq) : base ($index, $eq.remote) {
+        $this.eqId = $eq.identifier()
+
+        $this.cell = @()
+        $cellCount = $this.remote.kind.cells
+        for ($c = 0; $c -lt $cellCount; $c++) {
+            $this.cell.Add([EqCell]::new($c, $this))
+        }
+    }
+
+    [string] identifier () {
+        return '{0}.Channel[{1}]' -f $this.eqId, $this.index
+    }
+}
+
+class EqCell : IRemote {
+    [string]$channelId
+    
+    EqCell ([int]$index, [Object]$channel) : base ($index, $channel.remote) {
+        $this.channelId = $channel.identifier()
+
+        AddBoolMembers -PARAMS @('on')
+        AddIntMembers -PARAMS @('type')
+        AddFloatMembers -PARAMS @('f', 'gain', 'q')
+    }
+
+    [string] identifier () {
+        return '{0}.Cell[{1}]' -f $this.channelId, $this.index
+    }
+}

--- a/lib/eq.ps1
+++ b/lib/eq.ps1
@@ -1,29 +1,25 @@
 class Eq : IRemote {
     [System.Collections.ArrayList]$channel
-    [string]$prefix
+    [string]$kindOfEq
     
-    Eq ([int]$index, [Object]$remote, [string]$prefix, [int]$chCount) : base ($index, $remote) {
-        $this.prefix = $prefix
+    Eq ([int]$index, [Object]$remote, [string]$kindOfEq) : base ($index, $remote) {
+        $this.kindOfEq = $kindOfEq
 
         AddBoolMembers -PARAMS @('on', 'ab')
 
         $this.channel = @()
-        for ($ch = 0; $ch -lt $chCount; $ch++) {
+        for ($ch = 0; $ch -lt $remote.kind.eq_ch[$this.kindOfEq]; $ch++) {
             $this.channel.Add([EqChannel]::new($ch, $remote, $this.identifier()))
         }
     }
 
-    [string] identifier () {
-        return '{0}[{1}].EQ' -f $this.prefix, $this.index
-    }
-
     [void] Load ([string]$filename) {
-        $param = 'Command.Load{0}Eq[{1}]' -f $this.prefix, $this.index
+        $param = 'Command.Load{0}Eq[{1}]' -f $this.kindOfEq, $this.index
         $this.remote.Setter($param, $filename)
     }
 
     [void] Save ([string]$filename) {
-        $param = 'Command.Save{0}Eq[{1}]' -f $this.prefix, $this.index
+        $param = 'Command.Save{0}Eq[{1}]' -f $this.kindOfEq, $this.index
         $this.remote.Setter($param, $filename)
     }
 }

--- a/lib/eq.ps1
+++ b/lib/eq.ps1
@@ -2,15 +2,19 @@ class Eq : IRemote {
     [System.Collections.ArrayList]$channel
     [string]$prefix
     
-    Eq ([string]$prefix, [int]$chCount, [Object]$parent) : base ($parent.index, $parent.remote) {
+    Eq ([int]$index, [Object]$remote, [string]$prefix, [int]$chCount) : base ($index, $remote) {
+        $this.prefix = $prefix
+
         AddBoolMembers -PARAMS @('on', 'ab')
 
         $this.channel = @()
         for ($ch = 0; $ch -lt $chCount; $ch++) {
-            $this.channel.Add([EqChannel]::new($ch, $this))
+            $this.channel.Add([EqChannel]::new($ch, $remote, $this.identifier()))
         }
+    }
 
-        $this.prefix = $prefix
+    [string] identifier () {
+        return '{0}[{1}].EQ' -f $this.prefix, $this.index
     }
 
     [void] Load ([string]$filename) {
@@ -28,13 +32,13 @@ class EqChannel : IRemote {
     [System.Collections.ArrayList]$cell
     [string]$eqId
     
-    EqChannel ([int]$index, [Object]$eq) : base ($index, $eq.remote) {
-        $this.eqId = $eq.identifier()
+    EqChannel ([int]$index, [Object]$remote, [string]$eqId) : base ($index, $remote) {
+        $this.eqId = $eqId
 
         $this.cell = @()
         $cellCount = $this.remote.kind.cells
         for ($c = 0; $c -lt $cellCount; $c++) {
-            $this.cell.Add([EqCell]::new($c, $this))
+            $this.cell.Add([EqCell]::new($c, $remote, $this.identifier()))
         }
     }
 
@@ -46,8 +50,8 @@ class EqChannel : IRemote {
 class EqCell : IRemote {
     [string]$channelId
     
-    EqCell ([int]$index, [Object]$channel) : base ($index, $channel.remote) {
-        $this.channelId = $channel.identifier()
+    EqCell ([int]$index, [Object]$remote, [string]$channelId) : base ($index, $remote) {
+        $this.channelId = $channelId
 
         AddBoolMembers -PARAMS @('on')
         AddIntMembers -PARAMS @('type')

--- a/lib/kinds.ps1
+++ b/lib/kinds.ps1
@@ -11,6 +11,9 @@ $KindMap = @{
         'insert'    = 0
         'vban_in'   = 4
         'vban_out'  = 4
+        'strip_ch'  = 0
+        'bus_ch'    = 0
+        'cells'     = 0
     };
     'banana' = @{
         'name'      = 'banana'
@@ -24,6 +27,9 @@ $KindMap = @{
         'insert'    = 22
         'vban_in'   = 8
         'vban_out'  = 8
+        'strip_ch'  = 0
+        'bus_ch'    = 8
+        'cells'     = 6
     };
     'potato' = @{
         'name'      = 'potato'
@@ -37,6 +43,9 @@ $KindMap = @{
         'insert'    = 34
         'vban_in'   = 8
         'vban_out'  = 8
+        'strip_ch'  = 2
+        'bus_ch'    = 8
+        'cells'     = 6
     };
 }
 

--- a/lib/kinds.ps1
+++ b/lib/kinds.ps1
@@ -11,8 +11,7 @@ $KindMap = @{
         'insert'    = 0
         'vban_in'   = 4
         'vban_out'  = 4
-        'strip_ch'  = 0
-        'bus_ch'    = 0
+        'eq_ch'     = @{ 'strip' = 0; 'bus' = 0 }
         'cells'     = 0
     };
     'banana' = @{
@@ -27,8 +26,7 @@ $KindMap = @{
         'insert'    = 22
         'vban_in'   = 8
         'vban_out'  = 8
-        'strip_ch'  = 0
-        'bus_ch'    = 8
+        'eq_ch'     = @{ 'strip' = 0; 'bus' = 8 }
         'cells'     = 6
     };
     'potato' = @{
@@ -43,8 +41,7 @@ $KindMap = @{
         'insert'    = 34
         'vban_in'   = 8
         'vban_out'  = 8
-        'strip_ch'  = 2
-        'bus_ch'    = 8
+        'eq_ch'     = @{ 'strip' = 2; 'bus' = 8 }
         'cells'     = 6
     };
 }

--- a/lib/strip.ps1
+++ b/lib/strip.ps1
@@ -152,13 +152,8 @@ class StripDenoiser : IRemote {
     )
 }
 
-class StripEq : IRemote {
-    StripEq ([int]$index, [Object]$remote) : base ($index, $remote) {
-        AddBoolMembers -PARAMS @('on', 'ab')
-    }
-
-    [string] identifier () {
-        return 'Strip[' + $this.index + '].EQ'
+class StripEq : Eq {
+    StripEq ([int]$index, [Object]$remote) : base ($index, $remote, 'Strip', $remote.kind.strip_ch) {
     }
 }
 

--- a/lib/strip.ps1
+++ b/lib/strip.ps1
@@ -153,7 +153,11 @@ class StripDenoiser : IRemote {
 }
 
 class StripEq : Eq {
-    StripEq ([int]$index, [Object]$remote) : base ($index, $remote, 'Strip', $remote.kind.strip_ch) {
+    StripEq ([int]$index, [Object]$remote) : base ($index, $remote, 'Strip') {
+    }
+
+    [string] identifier () {
+        return 'Strip[' + $this.index + '].EQ'
     }
 }
 

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -27,25 +27,32 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             }
         }
 
-        Context 'physical only' -ForEach @(
+        Context 'Strip, physical only' -ForEach @(
             @{ Index = $phys_in }
         ) {
-            Context 'eq.{param}' -Skip:$ifNotPotato {
+            Context 'Eq' -Skip:$ifNotPotato -ForEach @(
+                @{ Eq = $vmr.strip[$index].eq }
+            ) {
                 It "Should set Strip[$index].EQ.On to $value" {
-                    $vmr.strip[$index].eq.on = $value
-                    $vmr.strip[$index].eq.on | Should -Be $expected
-                }                    
+                    $eq.on = $value
+                    $eq.on | Should -Be $value
+                }
+
+                It "Should set Strip[$index].EQ.AB to $value" {
+                    $eq.ab = $value
+                    $eq.ab | Should -Be $value
+                }
+
+                It "Should set Strip[$index].EQ.Channel[$strip_ch].Cell[$cells].On to $value" {
+                    $eq.channel[$strip_ch].cell[$cells].on = $value
+                    $eq.channel[$strip_ch].cell[$cells].on | Should -Be $value
+                }
             }
         }
 
         Context 'Bus, one physical one virtual' -ForEach @(
             @{ Index = $phys_out }, @{ Index = $virt_out }
         ) {
-            It "Should set and get Bus[$index].Eq.On" -Skip:$ifBasic {
-                $vmr.bus[$index].eq.on = $value
-                $vmr.bus[$index].eq.on | Should -Be $expected
-            }
-
             It "Should set and get Bus[$index].Mono" {
                 $vmr.bus[$index].mono = $value
                 $vmr.bus[$index].mono | Should -Be $expected
@@ -59,6 +66,25 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             It "Should set and get Bus[$index].mode.centeronly" -Skip:$ifBasic {
                 $vmr.bus[$index].mode.centeronly = $value
                 $vmr.bus[$index].mode.centeronly | Should -Be $expected
+            }
+
+            Context 'Eq' -Skip:$ifBasic -ForEach @(
+                @{ Eq = $vmr.bus[$index].eq }
+            ) {
+                It "Should set Bus[$index].EQ.On to $value" {
+                    $eq.on = $value
+                    $eq.on | Should -Be $value
+                }
+
+                It "Should set Bus[$index].EQ.AB to $value" {
+                    $eq.ab = $value
+                    $eq.ab | Should -Be $value
+                }
+
+                It "Should set Bus[$index].EQ.Channel[$bus_ch].Cell[$cells].On to $value" {
+                    $eq.channel[$bus_ch].cell[$cells].on = $value
+                    $eq.channel[$bus_ch].cell[$cells].on | Should -Be $value
+                }
             }
         }
 
@@ -146,95 +172,129 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
     }
 
     Describe 'Float Tests' {
-        Describe 'Strip tests' {
-            Context 'one physical, one virtual' -ForEach @(
-                @{ Index = $phys_in }, @{ Index = $virt_in }
+        Context 'Strip, one physical one virtual' -ForEach @(
+            @{ Index = $phys_in }, @{ Index = $virt_in }
+        ) {
+            It "Should set Strip[$index].Gain to $value" -ForEach @(
+                @{ Value = 3.6; Expected = 3.6 }, @{ Value = -8.2; Expected = -8.2 }
             ) {
-                Context 'gain' -ForEach @(
-                    @{ Value = 3.6; Expected = 3.6 }, @{ Value = -8.2; Expected = -8.2 }
-                ) {
-                    It "Should set Strip[$index].Gain to $value" {
-                        $vmr.strip[$index].gain = $value
-                        $vmr.strip[$index].gain | Should -Be $expected
-                    }                    
+                $vmr.strip[$index].gain = $value
+                $vmr.strip[$index].gain | Should -Be $expected
+            }
+        }
+
+        Context 'Strip, physical only' -Skip:$ifBasic -ForEach @(
+            @{ Index = $phys_in }
+        ) {
+            Context 'Knobs' -Skip:$ifBasic -ForEach @(
+                @{ Value = 8.3; Expected = 8.3 }, @{ Value = 5.1; Expected = 5.1 }
+            ) {
+                It "Should set Strip[$index].Comp to $value" {
+                    $vmr.strip[$index].comp.knob = $value
+                    $vmr.strip[$index].comp.knob | Should -Be $expected
+                }
+
+                It "Should set Strip[$index].Gate to $value" {
+                    $vmr.strip[$index].gate.knob = $value
+                    $vmr.strip[$index].gate.knob | Should -Be $expected
+                }
+
+                It "Should set Strip[$index].Denoiser to $value" -Skip:$ifNotPotato {
+                    $vmr.strip[$index].denoiser.knob = $value
+                    $vmr.strip[$index].denoiser.knob | Should -Be $expected
                 }
             }
 
-            Context 'physical only' -Skip:$ifBasic -ForEach @(
-                @{ Index = $phys_in }
-            ) {
-                Context 'comp, gate' -ForEach @(
+            Context 'Comp' -Skip:$ifNotPotato {
+                It "Should set Strip[$index].Comp.Attack" -ForEach @(
                     @{ Value = 8.3; Expected = 8.3 }, @{ Value = 5.1; Expected = 5.1 }
                 ) {
-                    It "Should set Strip[$index].Comp to $value" {
-                        $vmr.strip[$index].comp.knob = $value
-                        $vmr.strip[$index].comp.knob | Should -Be $expected
-                    }
-
-                    It "Should set Strip[$index].Gate to $value" {
-                        $vmr.strip[$index].gate.knob = $value
-                        $vmr.strip[$index].gate.knob | Should -Be $expected
-                    }
+                    $vmr.strip[$index].comp.attack = $value
+                    $vmr.strip[$index].comp.attack | Should -Be $expected
                 }
 
-                Context 'denoiser' -Skip:$ifNotPotato -ForEach @(
-                    @{ Value = 8.3; Expected = 8.3 }, @{ Value = 5.1; Expected = 5.1 }
-                ) {
-                    It "Should set Strip[$index].Denoiser to $value" {
-                        $vmr.strip[$index].denoiser.knob = $value
-                        $vmr.strip[$index].denoiser.knob | Should -Be $expected
-                    }
-                }
-
-                Context 'comp.{param}' -Skip:$ifNotPotato -ForEach @(
-                    @{ Value = 8.3; Expected = 8.3 }, @{ Value = 5.1; Expected = 5.1 }
-                ) {
-                    It "Should set Strip[$index].Comp.Attack to $value" {
-                        $vmr.strip[$index].comp.attack = $value
-                        $vmr.strip[$index].comp.attack | Should -Be $expected
-                    }
-                }
-
-                Context 'comp.{param}' -Skip:$ifNotPotato -ForEach @(
+                It "Should set Strip[$index].Comp.Knee" -ForEach @(
                     @{ Value = 0.3; Expected = 0.3 }, @{ Value = 0.8; Expected = 0.8 }
                 ) {
-                    It "Should set Strip[$index].Comp.Knee to $value" {
-                        $vmr.strip[$index].comp.knee = $value
-                        $vmr.strip[$index].comp.knee | Should -Be $expected
-                    }
+                    $vmr.strip[$index].comp.knee = $value
+                    $vmr.strip[$index].comp.knee | Should -Be $expected
                 }
+            }
 
-                Context 'gate.{param}' -Skip:$ifNotPotato -ForEach @(
-                    @{ Value = 103; Expected = 103 }, @{ Value = 3800; Expected = 3800 }
+            Context 'Gate' -Skip:$ifNotPotato {
+                It "Should set Strip[$index].Gate.BPSidechain" -ForEach @(
+                    @{ Value = 103.1; Expected = 103.1 }, @{ Value = 3800; Expected = 3800 }
                 ) {
-                    It "Should set Strip[$index].Gate.BPSidechain to $value" {
-                        $vmr.strip[$index].gate.bpsidechain = $value
-                        $vmr.strip[$index].gate.bpsidechain | Should -Be $expected
-                    }
+                    $vmr.strip[$index].gate.bpsidechain = $value
+                    $vmr.strip[$index].gate.bpsidechain | Should -Be $expected
                 }
 
-                Context 'gate.{param}' -Skip:$ifNotPotato -ForEach @(
+                It "Should set Strip[$index].Gate.Hold" -ForEach @(
                     @{ Value = 0.3; Expected = 0.3 }, @{ Value = 5000; Expected = 5000 }
                 ) {
-                    It "Should set Strip[$index].Gate.Hold to $value" {
-                        $vmr.strip[$index].gate.hold = $value
-                        $vmr.strip[$index].gate.hold | Should -Be $expected
-                    }
+                    $vmr.strip[$index].gate.hold = $value
+                    $vmr.strip[$index].gate.hold | Should -Be $expected
                 }
-            }            
+            }
+
+            Context 'EQ' -Skip:$ifNotPotato -ForEach @(
+                @{ Eq = $vmr.strip[$index].eq }
+            ) {
+                It "Should set Strip[$index].EQ.Channel[$strip_ch].Cell[$cells].F" -ForEach @(
+                    @{ Value = 1234.6; Expected = 1234.6 }, @{ Value = 7500; Expected = 7500 }
+                ) {
+                    $eq.channel[$strip_ch].cell[$cells].f = $value
+                    $eq.channel[$strip_ch].cell[$cells].f | Should -Be $expected
+                }
+
+                It "Should set Strip[$index].EQ.Channel[$strip_ch].Cell[$cells].Gain" -ForEach @(
+                    @{ Value = 4.2; Expected = 4.2 }, @{ Value = -7.3; Expected = -7.3 }
+                ) {
+                    $eq.channel[$strip_ch].cell[$cells].gain = $value
+                    $eq.channel[$strip_ch].cell[$cells].gain | Should -Be $expected
+                }
+
+                It "Should set Strip[$index].EQ.Channel[$strip_ch].Cell[$cells].Q" -ForEach @(
+                    @{ Value = 1.2; Expected = 1.2 }, @{ Value = 5.6; Expected = 5.6 }
+                ) {
+                    $eq.channel[$strip_ch].cell[$cells].q = $value
+                    $eq.channel[$strip_ch].cell[$cells].q | Should -Be $expected
+                }
+            }
         }
 
-        Describe 'Bus tests' {
-            Context 'one physical, one virtual' -ForEach @(
-                @{ Index = $phys_out }, @{ Index = $virt_out }
+        Context 'Bus, one physical one virtual' -ForEach @(
+            @{ Index = $phys_out }, @{ Index = $virt_out }
+        ) {
+            It "Should set Bus[$index].Gain" -ForEach @(
+                @{ Value = 5.2; Expected = 5.2 }, @{ Value = -38.2; Expected = -38.2 }
             ) {
-                Context 'gain' -ForEach @(
-                    @{ Value = 5.2; Expected = 5.2 }, @{ Value = -38.2; Expected = -38.2 }
+                $vmr.bus[$index].gain = $value
+                $vmr.bus[$index].gain | Should -Be $expected
+            }
+
+            Context 'EQ' -Skip:$ifBasic -ForEach @(
+                @{ Eq = $vmr.bus[$index].eq }
+            ) {
+                It "Should set Bus[$index].EQ.Channel[$bus_ch].Cell[$cells].F" -ForEach @(
+                    @{ Value = 1234.6; Expected = 1234.6 }, @{ Value = 7500; Expected = 7500 }
                 ) {
-                    It "Should set Bus[$index].Gain to $value" {
-                        $vmr.bus[$index].gain = $value
-                        $vmr.bus[$index].gain | Should -Be $expected
-                    }                    
+                    $eq.channel[$bus_ch].cell[$cells].f = $value
+                    $eq.channel[$bus_ch].cell[$cells].f | Should -Be $expected
+                }
+
+                It "Should set Bus[$index].EQ.Channel[$bus_ch].Cell[$cells].Gain" -ForEach @(
+                    @{ Value = 4.2; Expected = 4.2 }, @{ Value = -7.3; Expected = -7.3 }
+                ) {
+                    $eq.channel[$bus_ch].cell[$cells].gain = $value
+                    $eq.channel[$bus_ch].cell[$cells].gain | Should -Be $expected
+                }
+
+                It "Should set Bus[$index].EQ.Channel[$bus_ch].Cell[$cells].Q" -ForEach @(
+                    @{ Value = 1.2; Expected = 1.2 }, @{ Value = 5.6; Expected = 5.6 }
+                ) {
+                    $eq.channel[$bus_ch].cell[$cells].q = $value
+                    $eq.channel[$bus_ch].cell[$cells].q | Should -Be $expected
                 }
             }
         }
@@ -270,6 +330,32 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             Context 'Device' {
                 It "Should get Strip[$index].Device.sr" {
                     $vmr.strip[$index].device.sr | Should -BeOfType [int]
+                }
+            }
+
+            Context 'Eq' -Skip:$ifNotPotato -ForEach @(
+                @{ Eq = $vmr.strip[$index].eq }
+            ) {
+                It "Should set Strip[$index].EQ.Channel[$strip_ch].Cell[$cells].Type" -ForEach @(
+                    @{ Value = 0; Expected = 0 }, @{ Value = 6; Expected = 6 }
+                ) {
+                    $eq.channel[$strip_ch].cell[$cells].type = $value
+                    $eq.channel[$strip_ch].cell[$cells].type | Should -Be $expected
+                }
+            }
+        }
+
+        Context 'Bus, one physical one virtual' -ForEach @(
+            @{ Index = $phys_out }, @{ Index = $virt_out }
+        ) {
+            Context 'Eq' -Skip:$ifBasic -ForEach @(
+                @{ Eq = $vmr.bus[$index].eq }
+            ) {
+                It "Should set Bus[$index].EQ.Channel[$bus_ch].Cell[$cells].Type" -ForEach @(
+                    @{ Value = 0; Expected = 0 }, @{ Value = 6; Expected = 6 }
+                ) {
+                    $eq.channel[$bus_ch].cell[$cells].type = $value
+                    $eq.channel[$bus_ch].cell[$cells].type | Should -Be $expected
                 }
             }
         }
@@ -393,6 +479,49 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                     $vmr.strip[$index].device.name | Should -Be $value
                 }
             }
+
+            Context 'EQ' -Skip:$ifNotPotato -ForEach @(
+                @{ Eq = $vmr.strip[$index].eq }
+            ) {
+                It "Should save then load Strip[$index].EQ" -ForEach @(
+                    @{ Fq = 1234.5; Gain = 4.2; Ql = 56.2; Type = 3 }
+                ) {
+                    $tmp = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "vmreq-$(New-Guid).xml")
+                    try {
+                        # set some values
+                        $eq.channel[$strip_ch].cell[$cells].f = $fq
+                        $eq.channel[$strip_ch].cell[$cells].gain = $gain
+                        $eq.channel[$strip_ch].cell[$cells].q = $ql
+                        $eq.channel[$strip_ch].cell[$cells].type = $type
+                        
+                        # save eq
+                        $eq.Save($tmp)
+                        Start-Sleep -Milliseconds 100
+                        Test-Path $tmp | Should -BeTrue
+
+                        # change values
+                        $eq.channel[$strip_ch].cell[$cells].f = 1000
+                        $eq.channel[$strip_ch].cell[$cells].gain = 0
+                        $eq.channel[$strip_ch].cell[$cells].q = 1
+                        $eq.channel[$strip_ch].cell[$cells].type = 0
+
+                        # load eq
+                        $eq.Load($tmp)
+                        Start-Sleep -Milliseconds 100
+
+                        # verify values
+                        $eq.channel[$strip_ch].cell[$cells].f | Should -Be $fq
+                        $eq.channel[$strip_ch].cell[$cells].gain | Should -Be $gain
+                        $eq.channel[$strip_ch].cell[$cells].q | Should -Be $ql
+                        $eq.channel[$strip_ch].cell[$cells].type | Should -Be $type
+                    }
+                    finally {
+                        if (Test-Path $tmp) {
+                            Remove-Item $tmp -Force
+                        }
+                    }
+                }
+            }
         }
 
         Context 'Bus, one physical, one virtual' -ForEach @(
@@ -404,6 +533,49 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             ) {
                 $vmr.bus[$index].label = $value
                 $vmr.bus[$index].label | Should -Be $expected
+            }
+
+            Context 'EQ' -Skip:$ifBasic -ForEach @(
+                @{ Eq = $vmr.bus[$index].eq }
+            ) {
+                It "Should save then load Bus[$index].EQ" -ForEach @(
+                    @{ Fq = 1234.5; Gain = 4.2; Ql = 56.2; Type = 3 }
+                ) {
+                    $tmp = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "vmreq-$(New-Guid).xml")
+                    try {
+                        # set some values
+                        $eq.channel[$bus_ch].cell[$cells].f = $fq
+                        $eq.channel[$bus_ch].cell[$cells].gain = $gain
+                        $eq.channel[$bus_ch].cell[$cells].q = $ql
+                        $eq.channel[$bus_ch].cell[$cells].type = $type
+                        
+                        # save eq
+                        $eq.Save($tmp)
+                        Start-Sleep -Milliseconds 100
+                        Test-Path $tmp | Should -BeTrue
+
+                        # change values
+                        $eq.channel[$bus_ch].cell[$cells].f = 1000
+                        $eq.channel[$bus_ch].cell[$cells].gain = 0
+                        $eq.channel[$bus_ch].cell[$cells].q = 1
+                        $eq.channel[$bus_ch].cell[$cells].type = 0
+
+                        # load eq
+                        $eq.Load($tmp)
+                        Start-Sleep -Milliseconds 100
+
+                        # verify values
+                        $eq.channel[$bus_ch].cell[$cells].f | Should -Be $fq
+                        $eq.channel[$bus_ch].cell[$cells].gain | Should -Be $gain
+                        $eq.channel[$bus_ch].cell[$cells].q | Should -Be $ql
+                        $eq.channel[$bus_ch].cell[$cells].type | Should -Be $type
+                    }
+                    finally {
+                        if (Test-Path $tmp) {
+                            Remove-Item $tmp -Force
+                        }
+                    }
+                }
             }
         }
 

--- a/tests/run.ps1
+++ b/tests/run.ps1
@@ -18,6 +18,9 @@ function main() {
         $vban_out = $vmr.kind.vban_out - 1
         $insert = $vmr.kind.insert - 1
         $composite = $vmr.kind.composite - 1
+        $strip_ch = $vmr.kind.strip_ch - 1
+        $bus_ch = $vmr.kind.bus_ch - 1
+        $cells = $vmr.kind.cells - 1
 
         # skip conditions by kind
         $ifBasic = $vmr.kind.name -eq 'basic'


### PR DESCRIPTION
Closes #14 

## What

Adds Eq class as base for BusEq and StripEq with:
- on
- ab
- channel[i].cell[j].on
- channel[i].cell[j].type
- channel[i].cell[j].f
- channel[i].cell[j].gain
- channel[i].cell[j].q
- Load($filename)
- Save($filename)

## Test summary

Pester tests pass for all kinds, no manual tests needed

## Questions for reviewers

For consistency with Vban and Eq, I plan to submit a small PR moving 'identifier' to device.ps1 or I could do that here if you think it's relevant enough. If you'd rather Eq and Device have their identifier methods in bus.ps1 and strip.ps1, I can make the inverse change here instead.