### PR TITLE
Vban fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Before any major/minor/patch is released all test units will be run to verify th
 - EQ class
 - FX class
 - Vban.port sets Vban.Instream[0].port
+- Vban Midi and Command streams
+  - on, write-only
+  - name, write-only
+  - ip, write-only
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,25 @@ Before any major/minor/patch is released all test units will be run to verify th
 - Device classes
 - EQ class
 - FX class
+- Vban.port sets Vban.Instream[0].port
+
+### Changed
+
+- some vban.instream | vban.outstream commands now added with meta functions
+  - on
+  - name
+  - ip
+- cast vban getters to types for consistency
+
+### Fixed
+
+- some vban commands incorrectly read-only/write-only
+  - enable
+  - instream|outstream.quality
+  - instream|outstream.route
+- vban.stream.port: [string]$arg -> [int]$arg
+- vban route range (API documentation is incorrect)
+- vban.stream.sr: $this._port -> $this._sr
 
 ## [3.3.0] - 2024-06-29
 

--- a/README.md
+++ b/README.md
@@ -382,14 +382,16 @@ $vmr.button[5].trigger = $true
 
 ### VBAN
 
-- vmr.vban.enable: Toggle VBAN on or off. Accepts a bool value.
+The following vban commands are available:
+
+- enable: bool
+- port: int, from 1024 - 65535
 
 For each vban in/out stream the following parameters are defined:
 
 - on: bool
 - name: string
 - ip: string
-- port: int, from 1024 - 65535
 - sr: in, (11025, 16000, 22050, 24000, 32000, 44100, 48000, 64000, 88200, 96000)
 - channel: int from 1 to 8
 - bit: int, 16 or 24
@@ -403,9 +405,9 @@ example:
 
 ```powershell
 $vmr.vban.enable = $true
+$vmr.vban.port = 6990
 
 $vmr.vban.instream[0].on = $true
-$vmr.vban.instream[2].port = 6990
 $vmr.vban.outstream[3].bit = 16
 ```
 

--- a/lib/kinds.ps1
+++ b/lib/kinds.ps1
@@ -9,8 +9,7 @@ $KindMap = @{
         'asio_out'  = 8
         'composite' = 0
         'insert'    = 0
-        'vban_in'   = 4
-        'vban_out'  = 4
+        'vban'      = @{ 'in' = 4; 'out' = 4; 'midi' = 1; 'text' = 1 }
         'eq_ch'     = @{ 'strip' = 0; 'bus' = 0 }
         'cells'     = 0
     };
@@ -24,8 +23,7 @@ $KindMap = @{
         'asio_out'  = 8
         'composite' = 8
         'insert'    = 22
-        'vban_in'   = 8
-        'vban_out'  = 8
+        'vban'      = @{ 'in' = 8; 'out' = 8; 'midi' = 1; 'text' = 1 }
         'eq_ch'     = @{ 'strip' = 0; 'bus' = 8 }
         'cells'     = 6
     };
@@ -39,8 +37,7 @@ $KindMap = @{
         'asio_out'  = 8
         'composite' = 8
         'insert'    = 34
-        'vban_in'   = 8
-        'vban_out'  = 8
+        'vban'      = @{ 'in' = 8; 'out' = 8; 'midi' = 1; 'text' = 1 }
         'eq_ch'     = @{ 'strip' = 2; 'bus' = 8 }
         'cells'     = 6
     };

--- a/lib/vban.ps1
+++ b/lib/vban.ps1
@@ -10,8 +10,8 @@ class Vban : IRemote {
     }
 }
 
-class VbanStream : Vban {
-    VbanStream ([int]$index, [Object]$remote, [string]$direction) : base ($index, $remote, $direction) {
+class VbanAudio : Vban {
+    VbanAudio ([int]$index, [Object]$remote, [string]$direction) : base ($index, $remote, $direction) {
         AddBoolMembers -PARAMS @('on')
         AddStringMembers -PARAMS @('name', 'ip')
     }
@@ -190,8 +190,8 @@ class VbanText : Vban {
     )
 }
 
-class VbanInstream : VbanStream {
-    VbanInstream ([int]$index, [Object]$remote) : base ($index, $remote, 'in') {
+class VbanInAudio : VbanAudio {
+    VbanInAudio ([int]$index, [Object]$remote) : base ($index, $remote, 'in') {
     }
 }
 
@@ -205,8 +205,8 @@ class VbanInText : VbanText {
     }
 }
 
-class VbanOutstream : VbanStream {
-    VbanOutstream ([int]$index, [Object]$remote) : base ($index, $remote, 'out') {
+class VbanOutAudio : VbanAudio {
+    VbanOutAudio ([int]$index, [Object]$remote) : base ($index, $remote, 'out') {
     }
 }
 
@@ -224,7 +224,7 @@ function Make_Vban ([Object]$remote) {
 
     for ($i = 0; $i -lt $totalInstreams; $i++) {
         if ($i -lt $remote.kind.vban.in) {
-            [void]$instream.Add([VbanInstream]::new($i, $remote))
+            [void]$instream.Add([VbanInAudio]::new($i, $remote))
         }
         elseif ($i -lt ($remote.kind.vban.in + $remote.kind.vban.midi)) {
             [void]$instream.Add([VbanInMidi]::new($i, $remote))
@@ -235,7 +235,7 @@ function Make_Vban ([Object]$remote) {
     }
     for ($i = 0; $i -lt $totalOutstreams; $i++) {
         if ($i -lt $remote.kind.vban.out) {
-            [void]$outstream.Add([VbanOutstream]::new($i, $remote))
+            [void]$outstream.Add([VbanOutAudio]::new($i, $remote))
         }
         else {
             [void]$outstream.Add([VbanOutMidi]::new($i, $remote))

--- a/lib/vban.ps1
+++ b/lib/vban.ps1
@@ -3,48 +3,21 @@ class Vban : IRemote {
     
     Vban ([int]$index, [Object]$remote, [string]$direction) : base ($index, $remote) {
         $this.direction = $direction
+
+        AddBoolMembers -PARAMS @('on')
+        AddStringMembers -PARAMS @('name', 'ip')
     }
 
     [string] identifier () {
         return 'vban.' + $this.direction + 'stream[' + $this.index + ']'
     }
 
-    hidden $_on = $($this | Add-Member ScriptProperty 'on' `
-        {
-            $this.Getter('on')
-        } `
-        {
-            param([bool]$arg)
-            $this._on = $this.Setter('on', $arg)
-        }
-    )
-
-    hidden $_name = $($this | Add-Member ScriptProperty 'name' `
-        {
-            $this.Getter_String('name')
-        } `
-        {
-            param([string]$arg)
-            $this._name = $this.Setter('name', $arg)
-        }
-    )
-
-    hidden $_ip = $($this | Add-Member ScriptProperty 'ip' `
-        {
-            $this.Getter_String('ip')
-        } `
-        {
-            param([string]$arg)
-            $this._ip = $this.Setter('ip', $arg)
-        }
-    )
-
     hidden $_port = $($this | Add-Member ScriptProperty 'port' `
         {
-            $this.Getter('port')
+            [int]$this.Getter('port')
         } `
         {
-            param([string]$arg)
+            param([int]$arg)
             if ($arg -ge 1024 -and $arg -le 65535) {
                 $this._port = $this.Setter('port', $arg)
             }
@@ -56,7 +29,7 @@ class Vban : IRemote {
 
     hidden $_sr = $($this | Add-Member ScriptProperty 'sr' `
         {
-            $this.Getter('sr')
+            [int]$this.Getter('sr')
         } `
         {
             param([int]$arg)
@@ -64,7 +37,7 @@ class Vban : IRemote {
             else {
                 $opts = @(11025, 16000, 22050, 24000, 32000, 44100, 48000, 64000, 88200, 96000)
                 if ($opts.Contains($arg)) {
-                    $this._port = $this.Setter('sr', $arg)
+                    $this._sr = $this.Setter('sr', $arg)
                 }
                 else {
                     Write-Warning ('Expected one of', $opts)
@@ -75,7 +48,7 @@ class Vban : IRemote {
 
     hidden $_channel = $($this | Add-Member ScriptProperty 'channel' `
         {
-            $this.Getter('channel')
+            [int]$this.Getter('channel')
         } `
         {
             param([int]$arg)
@@ -113,36 +86,31 @@ class Vban : IRemote {
 
     hidden $_quality = $($this | Add-Member ScriptProperty 'quality' `
         {
-            $this.Getter('quality')
+            [int]$this.Getter('quality')
         } `
         {
             param([int]$arg)
-            if ($this.direction -eq 'in') { Write-Warning ('Error, read only value') }
+            if ($arg -ge 0 -and $arg -le 4) {
+                $this._quality = $this.Setter('quality', $arg)
+            }
             else {
-                if ($arg -ge 0 -and $arg -le 4) {
-                    $this._quality = $this.Setter('quality', $arg)
-                }
-                else {
-                    Write-Warning ('Expected value from 0 to 4')
-                }
+                Write-Warning ('Expected value from 0 to 4')
             }
         }
     )
 
     hidden $_route = $($this | Add-Member ScriptProperty 'route' `
         {
-            $this.Getter('route')
+            [int]$this.Getter('route')
         } `
         {
             param([int]$arg)
-            if ($this.direction -eq 'in') { Write-Warning ('Error, read only value') }
+            $rt = $this.remote.kind['p_' + $this.direction] + $this.remote.kind['v_' + $this.direction] - 1
+            if ($arg -ge 0 -and $arg -le $rt) {
+                $this._route = $this.Setter('route', $arg)
+            }
             else {
-                if ($arg -ge 0 -and $arg -le 8) {
-                    $this._route = $this.Setter('route', $arg)
-                }
-                else {
-                    Write-Warning ('Expected value from 0 to 8')
-                }
+                Write-Warning ("Expected value from 0 to $rt")
             }
         }
     )
@@ -179,11 +147,25 @@ function Make_Vban ([Object]$remote) {
 
     $CustomObject | Add-Member ScriptProperty 'enable' `
     {
-        return Write-Warning ('ERROR: vban.enable is write only')
+        return [bool]( Param_Get -PARAM 'vban.enable' )
     } `
     {
         param([bool]$arg)
-        Param_Set -PARAM 'vban.Enable' -Value $(if ($arg) { 1 } else { 0 })
+        Param_Set -PARAM 'vban.enable' -Value $(if ($arg) { 1 } else { 0 })
+    }
+
+    $CustomObject | Add-Member ScriptProperty 'port' `
+    {
+        return [int]( Param_Get -PARAM 'vban.instream[0].port' )
+    } `
+    {
+        param([int]$arg)
+        if ($arg -ge 1024 -and $arg -le 65535) {
+            Param_Set -PARAM 'vban.instream[0].port' -Value $arg
+        }
+        else {
+            Write-Warning ('Expected value from 1024 to 65535')
+        }
     }
 
     $CustomObject

--- a/lib/vban.ps1
+++ b/lib/vban.ps1
@@ -3,13 +3,17 @@ class Vban : IRemote {
     
     Vban ([int]$index, [Object]$remote, [string]$direction) : base ($index, $remote) {
         $this.direction = $direction
-
-        AddBoolMembers -PARAMS @('on')
-        AddStringMembers -PARAMS @('name', 'ip')
     }
 
     [string] identifier () {
         return 'vban.' + $this.direction + 'stream[' + $this.index + ']'
+    }
+}
+
+class VbanStream : Vban {
+    VbanStream ([int]$index, [Object]$remote, [string]$direction) : base ($index, $remote, $direction) {
+        AddBoolMembers -PARAMS @('on')
+        AddStringMembers -PARAMS @('name', 'ip')
     }
 
     hidden $_port = $($this | Add-Member ScriptProperty 'port' `
@@ -116,28 +120,126 @@ class Vban : IRemote {
     )
 }
 
+class VbanMidi : Vban {
+    VbanMidi ([int]$index, [Object]$remote, [string]$direction) : base ($index, $remote, $direction) {
+    }
 
-class VbanInstream : Vban {
-    VbanInstream ([int]$index, [Object]$remote, [string]$direction) : base ($index, $remote, $direction) {
+    hidden $_on = $($this | Add-Member ScriptProperty 'on' `
+        {
+            return Write-Warning ("ERROR: $($this.identifier()).on is write only")
+        } `
+        {
+            param([bool]$arg)
+            $this._on = $this.Setter('on', $arg)
+        }
+    )
+
+    hidden $_name = $($this | Add-Member ScriptProperty 'name' `
+        {
+            return Write-Warning ("ERROR: $($this.identifier()).name is write only")
+        } `
+        {
+            param([string]$arg)
+            $this._name = $this.Setter('name', $arg)
+        }
+    )
+
+    hidden $_ip = $($this | Add-Member ScriptProperty 'ip' `
+        {
+            return Write-Warning ("ERROR: $($this.identifier()).ip is write only")
+        } `
+        {
+            param([string]$arg)
+            $this._ip = $this.Setter('ip', $arg)
+        }
+    )
+}
+
+class VbanText : Vban {
+    VbanText ([int]$index, [Object]$remote, [string]$direction) : base ($index, $remote, $direction) {
+    }
+
+    hidden $_on = $($this | Add-Member ScriptProperty 'on' `
+        {
+            return Write-Warning ("ERROR: $($this.identifier()).on is write only")
+        } `
+        {
+            param([bool]$arg)
+            $this._on = $this.Setter('on', $arg)
+        }
+    )
+
+    hidden $_name = $($this | Add-Member ScriptProperty 'name' `
+        {
+            return Write-Warning ("ERROR: $($this.identifier()).name is write only")
+        } `
+        {
+            param([string]$arg)
+            $this._name = $this.Setter('name', $arg)
+        }
+    )
+
+    hidden $_ip = $($this | Add-Member ScriptProperty 'ip' `
+        {
+            return Write-Warning ("ERROR: $($this.identifier()).ip is write only")
+        } `
+        {
+            param([string]$arg)
+            $this._ip = $this.Setter('ip', $arg)
+        }
+    )
+}
+
+class VbanInstream : VbanStream {
+    VbanInstream ([int]$index, [Object]$remote) : base ($index, $remote, 'in') {
     }
 }
 
-
-class VbanOutstream : Vban {
-    VbanOutstream ([int]$index, [Object]$remote, [string]$direction) : base ($index, $remote, $direction) {
+class VbanInMidi : VbanMidi {
+    VbanInMidi ([int]$index, [Object]$remote) : base ($index, $remote, 'in') {
     }
 }
 
+class VbanInText : VbanText {
+    VbanInText ([int]$index, [Object]$remote) : base ($index, $remote, 'in') {
+    }
+}
+
+class VbanOutstream : VbanStream {
+    VbanOutstream ([int]$index, [Object]$remote) : base ($index, $remote, 'out') {
+    }
+}
+
+class VbanOutMidi : VbanMidi {
+    VbanOutMidi ([int]$index, [Object]$remote) : base ($index, $remote, 'out') {
+    }
+}
 
 function Make_Vban ([Object]$remote) {
     [System.Collections.ArrayList]$instream = @()
     [System.Collections.ArrayList]$outstream = @()
 
-    0..$($remote.kind.vban_in - 1) | ForEach-Object {
-        [void]$instream.Add([VbanInstream]::new($_, $remote, 'in'))
+    $totalInstreams = $remote.kind.vban.in + $remote.kind.vban.midi + $remote.kind.vban.text
+    $totalOutstreams = $remote.kind.vban.out + $remote.kind.vban.midi
+
+    for ($i = 0; $i -lt $totalInstreams; $i++) {
+        if ($i -lt $remote.kind.vban.in) {
+            [void]$instream.Add([VbanInstream]::new($i, $remote))
+        }
+        elseif ($i -lt ($remote.kind.vban.in + $remote.kind.vban.midi)) {
+            [void]$instream.Add([VbanInMidi]::new($i, $remote))
+        }
+        else {
+            [void]$instream.Add([VbanInText]::new($i, $remote))
+        }
     }
-    0..$($remote.kind.vban_out - 1) | ForEach-Object {
-        [void]$outstream.Add([VbanOutstream]::new($_, $remote, 'out'))
+    for ($i = 0; $i -lt $totalOutstreams; $i++) {
+        if ($i -lt $remote.kind.vban.out) {
+            [void]$outstream.Add([VbanOutstream]::new($i, $remote))
+        }
+        else {
+            [void]$outstream.Add([VbanOutMidi]::new($i, $remote))
+        }
     }
 
     $CustomObject = [pscustomobject]@{

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -106,7 +106,9 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             }
         
             Context 'Instream' -ForEach @(
-                @{ Index = $vban_in }
+                @{ Index = $vban_inA }
+                # @{ Index = $vban_inM }
+                # @{ Index = $vban_inT }
             ) {
                 It "Should set vban.instream[$index].on" {
                     $vmr.vban.instream[$index].on = $value
@@ -115,7 +117,8 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             }
 
             Context 'Outstream' -ForEach @(
-                @{ Index = $vban_out }
+                @{ Index = $vban_outA }
+                # @{ Index = $vban_outM }
             ) {
                 It "Should set vban.outstream[$index].on" {
                     $vmr.vban.outstream[$index].on = $value
@@ -427,7 +430,7 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             }
             
             Context 'Instream' -ForEach @(
-                @{ Index = $vban_in }
+                @{ Index = $vban_inA }
             ) {
                 It "Should set vban.instream[$index].port" -ForEach @(
                     @{ Value = 1024; Expected = 1024 }
@@ -470,7 +473,7 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             }
             
             Context 'Outstream' -ForEach @(
-                @{ Index = $vban_out }
+                @{ Index = $vban_outA }
             ) {
                 It "Should set vban.outstream[$index].port" -ForEach @(
                     @{ Value = 1024; Expected = 1024 }
@@ -758,7 +761,9 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
 
         Describe 'Vban' {
             Context 'Instream' -ForEach @(
-                @{ Index = $vban_in }
+                @{ Index = $vban_inA }
+                # @{ Index = $vban_inM }
+                # @{ Index = $vban_inT }
             ) {
                 It "Should set vban.instream[$index].name" -ForEach @(
                     @{ Value = 'TestIn0'; Expected = 'TestIn0' }
@@ -777,7 +782,8 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             }
 
             Context 'Outstream' -ForEach @(
-                @{ Index = $vban_out }
+                @{ Index = $vban_outA }
+                # @{ Index = $vban_outM }
             ) {
                 It "Should set vban.outstream[$index].name" -ForEach @(
                     @{ Value = 'TestOut0'; Expected = 'TestOut0' }

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -1,5 +1,5 @@
 Describe -Tag 'higher', -TestName 'All Higher Tests' {
-    Describe 'Bool tests' -ForEach @(
+    Describe 'Bool tests' -Tag 'bool' -ForEach @(
         @{ Value = $true; Expected = $true }
         @{ Value = $false; Expected = $false }
     ) {
@@ -97,21 +97,30 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             }
         }
 
-        Context 'Vban instream' -ForEach @(
-            @{ Index = $vban_in }
-        ) {
-            It "Should set vban.instream[$index].on" {
-                $vmr.vban.instream[$index].on = $value
-                $vmr.vban.instream[$index].on | Should -Be $expected
+        Context 'Vban' {
+            It 'Should set and get Vban.enable' {
+                $vmr.vban.enable = $value
+                $vmr.command.restart
+                Start-Sleep -Milliseconds 2000
+                $vmr.vban.enable | Should -Be $expected
             }
-        }
+        
+            Context 'Instream' -ForEach @(
+                @{ Index = $vban_in }
+            ) {
+                It "Should set vban.instream[$index].on" {
+                    $vmr.vban.instream[$index].on = $value
+                    $vmr.vban.instream[$index].on | Should -Be $expected
+                }
+            }
 
-        Context 'Vban outstream' -ForEach @(
-            @{ Index = $vban_out }
-        ) {
-            It "Should set vban.outstream[$index].on" {
-                $vmr.vban.outstream[$index].on = $value
-                $vmr.vban.outstream[$index].on | Should -Be $expected
+            Context 'Outstream' -ForEach @(
+                @{ Index = $vban_out }
+            ) {
+                It "Should set vban.outstream[$index].on" {
+                    $vmr.vban.outstream[$index].on = $value
+                    $vmr.vban.outstream[$index].on | Should -Be $expected
+                }
             }
         }
 
@@ -184,20 +193,20 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             It 'Should set and get Option.monitoronsel' -Skip:$ifNotPotato {
                 $vmr.option.monitoronsel = $value
                 $vmr.command.restart
-                Start-Sleep -Milliseconds 500
+                Start-Sleep -Milliseconds 2000
                 $vmr.option.monitoronsel | Should -Be $value
             }
             
             It 'Should set and get Option.slidermode' -Skip:$ifNotPotato {
                 $vmr.option.slidermode = $value
                 $vmr.command.restart
-                Start-Sleep -Milliseconds 500
+                Start-Sleep -Milliseconds 2000
                 $vmr.option.slidermode | Should -Be $value
             }
         }
     }
 
-    Describe 'Float Tests' {
+    Describe 'Float Tests' -Tag 'float' {
         Context 'Strip, one physical one virtual' -ForEach @(
             @{ Index = $phys_in }, @{ Index = $virt_in }
         ) {
@@ -331,13 +340,13 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             ) {
                 $vmr.option.delay[$phys_out].set($value)
                 $vmr.command.restart
-                Start-Sleep -Milliseconds 500
+                Start-Sleep -Milliseconds 2000
                 $vmr.option.delay[$phys_out].get() | Should -Be $value
             }
         }
     }
 
-    Describe 'Int Tests' {
+    Describe 'Int Tests' -Tag 'int' {
         Context 'Strip, one physical, one virtual' -ForEach @(
             @{ Index = $phys_in }, @{ Index = $virt_in }
         ) {
@@ -406,23 +415,113 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             }
         }
 
-        Context 'Vban outstream' -ForEach @(
-            @{ Index = $vban_out }
-        ) {
-            It "Should set vban.outstream[$index].sr to $value" -ForEach @(
-                @{ Value = 44100; Expected = 44100 }
-                @{ Value = 48000; Expected = 48000 }
+        Context 'Vban' {
+            It 'Should set vban.port' -ForEach @(
+                @{ Value = 1024; Expected = 1024 }
+                @{ Value = 65535; Expected = 65535 }
             ) {
-                $vmr.vban.outstream[$index].sr = $value
-                $vmr.vban.outstream[$index].sr | Should -Be $expected
+                $vmr.vban.port = $value
+                $vmr.command.restart
+                Start-Sleep -Milliseconds 2000
+                $vmr.vban.port | Should -Be $expected
             }
-
-            It 'Should set vban.outstream[0].channel to 1' -ForEach @(
-                @{ Value = 1; Expected = 1 }
-                @{ Value = 2; Expected = 2 }
+            
+            Context 'Instream' -ForEach @(
+                @{ Index = $vban_in }
             ) {
-                $vmr.vban.outstream[$index].channel = $value
-                $vmr.vban.outstream[$index].channel | Should -Be $expected
+                It "Should set vban.instream[$index].port" -ForEach @(
+                    @{ Value = 1024; Expected = 1024 }
+                    @{ Value = 65535; Expected = 65535 }
+                ) {
+                    $vmr.vban.instream[$index].port = $value
+                    $vmr.command.restart
+                    Start-Sleep -Milliseconds 2000
+                    $vmr.vban.instream[$index].port | Should -Be $expected
+                }
+
+                It "Should set vban.instream[$index].sr" {
+                    $vmr.vban.instream[$index].sr | Should -BeOfType [int]
+                }
+
+                It "Should set vban.instream[$index].channel" {
+                    $vmr.vban.instream[$index].channel | Should -BeOfType [int]
+                }
+
+                It "Should set vban.instream[$index].bit" {
+                    $vmr.vban.instream[$index].bit | Should -BeOfType [int]
+                }
+
+                It "Should set vban.instream[$index].quality" -ForEach @(
+                    @{ Value = 0; Expected = 0 }
+                    @{ Value = 4; Expected = 4 }
+                ) {
+                    $vmr.vban.instream[$index].quality = $value
+                    Start-Sleep -Milliseconds 500
+                    $vmr.vban.instream[$index].quality | Should -Be $expected
+                }
+
+                It "Should set vban.instream[$index].route" -ForEach @(
+                    @{ Value = $phys_in; Expected = $phys_in }
+                    @{ Value = $virt_in; Expected = $virt_in }
+                ) {
+                    $vmr.vban.instream[$index].route = $value
+                    $vmr.vban.instream[$index].route | Should -Be $expected
+                }
+            }
+            
+            Context 'Outstream' -ForEach @(
+                @{ Index = $vban_out }
+            ) {
+                It "Should set vban.outstream[$index].port" -ForEach @(
+                    @{ Value = 1024; Expected = 1024 }
+                    @{ Value = 65535; Expected = 65535 }
+                ) {
+                    $vmr.vban.outstream[$index].port = $value
+                    $vmr.command.restart
+                    Start-Sleep -Milliseconds 2000
+                    $vmr.vban.outstream[$index].port | Should -Be $expected
+                }
+                
+                It "Should set vban.outstream[$index].sr" -ForEach @(
+                    @{ Value = 44100; Expected = 44100 }
+                    @{ Value = 48000; Expected = 48000 }
+                ) {
+                    $vmr.vban.outstream[$index].sr = $value
+                    $vmr.vban.outstream[$index].sr | Should -Be $expected
+                }
+
+                It "Should set vban.outstream[$index].channel" -ForEach @(
+                    @{ Value = 1; Expected = 1 }
+                    @{ Value = 2; Expected = 2 }
+                ) {
+                    $vmr.vban.outstream[$index].channel = $value
+                    $vmr.vban.outstream[$index].channel | Should -Be $expected
+                }
+
+                It "Should set vban.outstream[$index].bit" -ForEach @(
+                    @{ Value = 16; Expected = 16 }
+                    @{ Value = 24; Expected = 24 }
+                ) {
+                    $vmr.vban.outstream[$index].bit = $value
+                    $vmr.vban.outstream[$index].bit | Should -Be $expected
+                }
+
+                It "Should set vban.outstream[$index].quality" -ForEach @(
+                    @{ Value = 0; Expected = 0 }
+                    @{ Value = 4; Expected = 4 }
+                ) {
+                    $vmr.vban.outstream[$index].quality = $value
+                    Start-Sleep -Milliseconds 500
+                    $vmr.vban.outstream[$index].quality | Should -Be $expected
+                }
+
+                It "Should set vban.outstream[$index].route" -ForEach @(
+                    @{ Value = $phys_out; Expected = $phys_out }
+                    @{ Value = $virt_out; Expected = $virt_out }
+                ) {
+                    $vmr.vban.outstream[$index].route = $value
+                    $vmr.vban.outstream[$index].route | Should -Be $expected
+                }
             }
         }
         
@@ -468,7 +567,7 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
         }
     }
 
-    Describe 'String Tests' {
+    Describe 'String Tests' -Tag 'string' {
         Context 'Strip, one physical, one virtual' -ForEach @(
             @{ Index = $phys_in }, @{ Index = $virt_in }
         ) {
@@ -657,29 +756,43 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             }
         }
 
-        Describe 'Vban' -ForEach @(
-            @{ Index = $vban_in }
-        ) {
-            Context 'instream' {
-                Context 'ip' -ForEach @(
+        Describe 'Vban' {
+            Context 'Instream' -ForEach @(
+                @{ Index = $vban_in }
+            ) {
+                It "Should set vban.instream[$index].name" -ForEach @(
+                    @{ Value = 'TestIn0'; Expected = 'TestIn0' }
+                    @{ Value = 'TestIn1'; Expected = 'TestIn1' }
+                ) {
+                    $vmr.vban.instream[$index].name = $value
+                    $vmr.vban.instream[$index].name | Should -Be $expected
+                }
+                
+                It "Should set vban.instream[$index].ip" -ForEach @(
                     @{ Value = '0.0.0.0'; Expected = '0.0.0.0' }
                 ) {
-                    It "Should set vban.instream[$index].name to $value" {
-                        $vmr.vban.instream[$index].ip = $value
-                        $vmr.vban.instream[$index].ip | Should -Be $expected
-                    }
-                }                 
+                    $vmr.vban.instream[$index].ip = $value
+                    $vmr.vban.instream[$index].ip | Should -Be $expected
+                }
             }
 
-            Context 'outstream' {
-                Context 'ip' -ForEach @(
+            Context 'Outstream' -ForEach @(
+                @{ Index = $vban_out }
+            ) {
+                It "Should set vban.outstream[$index].name" -ForEach @(
+                    @{ Value = 'TestOut0'; Expected = 'TestOut0' }
+                    @{ Value = 'TestOut1'; Expected = 'TestOut1' }
+                ) {
+                    $vmr.vban.outstream[$index].name = $value
+                    $vmr.vban.outstream[$index].name | Should -Be $expected
+                }
+                
+                It "Should set vban.outstream[$index].ip" -ForEach @(
                     @{ Value = '0.0.0.0'; Expected = '0.0.0.0' }
                 ) {
-                    It "Should set vban.outstream[$index].name to $value" {
-                        $vmr.vban.outstream[$index].ip = $value
-                        $vmr.vban.outstream[$index].ip | Should -Be $expected
-                    }
-                }                  
+                    $vmr.vban.outstream[$index].ip = $value
+                    $vmr.vban.outstream[$index].ip | Should -Be $expected
+                }       
             }
         }
     }

--- a/tests/run.ps1
+++ b/tests/run.ps1
@@ -14,8 +14,11 @@ function main() {
         $virt_in = $vmr.kind.p_in + $vmr.kind.v_in - 1
         $phys_out = $vmr.kind.p_out - 1
         $virt_out = $vmr.kind.p_out + $vmr.kind.v_out - 1
-        $vban_in = $vmr.kind.vban_in - 1
-        $vban_out = $vmr.kind.vban_out - 1
+        $vban_inA = $vmr.kind.vban.in - 1
+        $vban_inM = $vmr.kind.vban.in + $vmr.kind.vban.midi - 1
+        $vban_inT = $vmr.kind.vban.in + $vmr.kind.vban.midi + $vmr.kind.vban.text - 1
+        $vban_outA = $vmr.kind.vban.out - 1
+        $vban_outM = $vmr.kind.vban.out + $vmr.kind.vban.midi - 1
         $insert = $vmr.kind.insert - 1
         $composite = $vmr.kind.composite - 1
         $strip_ch = $vmr.kind.eq_ch['strip'] - 1


### PR DESCRIPTION
Closes #18 

## What

Adds Vban.port and implements a handful of fixes and small changes to Vban

### Added

- Vban.port sets Vban.Instream[0].port
- Midi and Command streams now support write-only:
  - on
  - name
  - ip

### Changed

- some vban.instream | vban.outstream commands now added with meta functions
  - on
  - name
  - ip
- cast vban getters to types for consistency

### Fixed

- some vban commands incorrectly read-only/write-only
  - enable
  - instream|outstream.quality
  - instream|outstream.route
- vban.stream.port: [string]$arg -> [int]$arg
- vban route range (API documentation is incorrect)
- vban.stream.sr: $this._port -> $this._sr

## Test summary

Pester tests pass for all kinds, no manual tests needed