### PR TITLE
Bus params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Before any major/minor/patch is released all test units will be run to verify th
   - name, write-only
   - ip, write-only
 - Bus.Sel, Bus.Monitor, Bus.Vaio
+- Bus.Mode.Set($mode)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Before any major/minor/patch is released all test units will be run to verify th
   - on, write-only
   - name, write-only
   - ip, write-only
+- Bus.Sel, Bus.Monitor, Bus.Vaio
 
 ### Changed
 
@@ -31,6 +32,8 @@ Before any major/minor/patch is released all test units will be run to verify th
   - name
   - ip
 - cast vban getters to types for consistency
+- Bus.Mono -> [int] for stereo reverse
+- Bus.Levels.Convert return type [float] -> [single] for naming consistency, no functional change
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ The following bus.mode members are available:
 
 The following bus.mode commands are available:
 
+- Set($mode): string, sets the current bus mode
 - Get(): returns the current bus mode.
 
 for example:

--- a/README.md
+++ b/README.md
@@ -234,8 +234,10 @@ $vmr.strip[2].levels.PreFader() -Join ', ' | Write-Host
 The following bus commands are available:
 
 - mute: bool
-- mono: bool
-- limit: int, from -40 to 12
+- sel: bool
+- monitor: bool
+- vaio: bool
+- mono: int, 0 off, 1 mono, 2 stereo reverse
 - gain: float, from -60.0 to 12.0
 - label: string
 - returnreverb: float, from 0.0 to 10.0

--- a/lib/bus.ps1
+++ b/lib/bus.ps1
@@ -4,7 +4,8 @@ class Bus : IRemote {
     [Object]$levels
 
     Bus ([int]$index, [Object]$remote) : base ($index, $remote) {
-        AddBoolMembers -PARAMS @('mono', 'mute')
+        AddBoolMembers -PARAMS @('mute', 'sel', 'monitor')
+        AddIntMembers -PARAMS @('mono')
         AddStringMembers -PARAMS @('label')
         AddFloatMembers -PARAMS @('gain', 'returnreverb', 'returndelay', 'returnfx1', 'returnfx2')
 
@@ -35,7 +36,7 @@ class BusLevels : IRemote {
         $this.offset = 8            
     }
 
-    [float] Convert([float]$val) {
+    [single] Convert([single]$val) {
         if ($val -gt 0) { 
             return [math]::Round(20 * [math]::Log10($val), 1) 
         } 
@@ -97,6 +98,8 @@ class PhysicalBus : Bus {
 
     PhysicalBus ([int]$index, [Object]$remote) : base ($index, $remote) {
         $this.device = [BusDevice]::new($index, $remote)
+
+        AddBoolMembers -PARAMS @('vaio')
     }
 }
 
@@ -126,7 +129,7 @@ class BusDevice : Device {
             -Value {
             return Write-Warning ("ERROR: $($this.identifier()).asio is write only")
         } -SecondValue {
-            param($arg)
+            param([string]$arg)
             return $this.Setter('asio', $arg)
         } -Force
     }

--- a/lib/bus.ps1
+++ b/lib/bus.ps1
@@ -36,7 +36,7 @@ class BusLevels : IRemote {
         $this.offset = 8            
     }
 
-    [single] Convert([single]$val) {
+    hidden [single] Convert([single]$val) {
         if ($val -gt 0) { 
             return [math]::Round(20 * [math]::Log10($val), 1) 
         } 
@@ -81,6 +81,15 @@ class BusMode : IRemote {
             }
         }
         return $mode
+    }
+
+    [void] Set ([string]$mode) {
+        if ($this.modes.Contains($mode)) {
+            $this.Setter($mode, $true)
+        }
+        else {
+            throw [System.ArgumentException]::new("Invalid mode: $mode")
+        }
     }
 }
 

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -68,7 +68,7 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 $vmr.bus[$index].sel | Should -Be $expected
             }
 
-            It "Should set and get Bus[$index].mode.amix" -Skip:$ifBasic {
+            It "Should set and get Bus[$index].mode.amix" {
                 $vmr.bus[$index].mode.amix = $value
                 $vmr.bus[$index].mode.amix | Should -Be $expected
             }
@@ -689,6 +689,15 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             ) {
                 $vmr.bus[$index].label = $value
                 $vmr.bus[$index].label | Should -Be $expected
+            }
+
+            It "Should set Bus[$index].Mode" -Skip:$ifBasic -ForEach @(
+                @{ Value = 'bmix'; Expected = 'bmix' }
+                @{ Value = 'upmix41'; Expected = 'upmix41' }
+                @{ Value = 'rearonly'; Expected = 'rearonly' }
+            ) {
+                $vmr.bus[$index].mode.Set($value)
+                $vmr.bus[$index].mode.Get() | Should -Be $expected
             }
 
             Context 'EQ' -Skip:$ifBasic -ForEach @(

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -53,9 +53,19 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
         Context 'Bus, one physical one virtual' -ForEach @(
             @{ Index = $phys_out }, @{ Index = $virt_out }
         ) {
-            It "Should set and get Bus[$index].Mono" {
-                $vmr.bus[$index].mono = $value
-                $vmr.bus[$index].mono | Should -Be $expected
+            It "Should set and get Bus[$index].Monitor" -Skip:$ifNotPotato {
+                $vmr.bus[$index].monitor = $value
+                $vmr.bus[$index].monitor | Should -Be $expected
+            }
+
+            It "Should set and get Bus[$index].Mute" {
+                $vmr.bus[$index].mute = $value
+                $vmr.bus[$index].mute | Should -Be $expected
+            }
+
+            It "Should set and get Bus[$index].Sel" -Skip:$ifNotPotato {
+                $vmr.bus[$index].sel = $value
+                $vmr.bus[$index].sel | Should -Be $expected
             }
 
             It "Should set and get Bus[$index].mode.amix" -Skip:$ifBasic {
@@ -85,6 +95,15 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                     $eq.channel[$bus_ch].cell[$cells].on = $value
                     $eq.channel[$bus_ch].cell[$cells].on | Should -Be $value
                 }
+            }
+        }
+
+        Context 'Bus, physical only' -ForEach @(
+            @{ Index = $phys_out }
+        ) {
+            It "Should set and get Bus[$index].vaio" {
+                $vmr.bus[$index].vaio = $value
+                $vmr.bus[$index].vaio | Should -Be $expected
             }
         }
 
@@ -386,6 +405,15 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
         Context 'Bus, one physical one virtual' -ForEach @(
             @{ Index = $phys_out }, @{ Index = $virt_out }
         ) {
+            It "Should set and get Bus[$index].Mono" -ForEach @(
+                @{ Value = 0; Expected = 0 }
+                @{ Value = 1; Expected = 1 }
+                @{ Value = 2; Expected = 2 }
+            ) {
+                $vmr.bus[$index].mono = $value
+                $vmr.bus[$index].mono | Should -Be $expected
+            }
+            
             Context 'Eq' -Skip:$ifBasic -ForEach @(
                 @{ Eq = $vmr.bus[$index].eq }
             ) {


### PR DESCRIPTION
Closes #23  

## What

Adds a few commands and makes a few small changes.

### Added

```powershell
$vmr.bus[$i].sel
$vmr.bus[$i].monitor
$vmr.bus[$i].vaio
```

### Fixed/Changed

- Changed `mono` to `[int]`: 0 off, 1 mono, 2 stereo reverse; not a breaking change
- Changed `Levels.Convert` type `[float] -> [single]` for naming consistency; no functional change
- `asio` expects a string: `$arg -> [string]$arg` for clarity

## Testing/Notes

Pester tests pass for all kinds

Manual tests for safety pass:
- `Bus[i].levels.all()`
- `Bus[i].device.asio`

Removed `Bus[i].limit` from README as it does not exist.