### PR TITLE
AddActionMembers, types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Before any major/minor/patch is released all test units will be run to verify th
 
 ## [Unreleased] These changes have not been added to PSGallery yet
 
+### Breaking Changes
+
+AddActionMembers now adds ScriptMethods instead of ScriptProperties:
+- See Command section of README for details on using special commands
+- See Recorder section of README for details on using playback/record actions
+
 ### Added
 
 - IRemote base class
@@ -35,6 +41,8 @@ Before any major/minor/patch is released all test units will be run to verify th
 - cast vban getters to types for consistency
 - Bus.Mono -> [int] for stereo reverse
 - Bus.Levels.Convert return type [float] -> [single] for naming consistency, no functional change
+- Meta: AddBoolMembers, AddIntMembers $arg types for consistency
+- Device: explicit $arg types for consistency
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -420,15 +420,15 @@ Certain 'special' commands are defined by the API as performing actions rather t
 
 The following commands are available:
 
-- show
 - hide
-- restart
-- shutdown
 - showvbanchat: bool, (write only)
 - lock: bool, (write only)
 
 The following methods are available:
 
+- Show()
+- Restart()
+- Shutdown()
 - Load($filepath): string
 - RunMacrobuttons(): Launches the macrobuttons app
 - CloseMacrobuttons(): Closes the macrobuttons app
@@ -436,7 +436,7 @@ The following methods are available:
 example:
 
 ```powershell
-$vmr.command.show
+$vmr.command.show()
 
 $vmr.command.lock = $true
 
@@ -525,12 +525,6 @@ $vmr.Option.buffer.asio = 0    # to use default buffer size
 
 The following commands are available:
 
-- play
-- stop
-- pause
-- record
-- ff
-- rew
 - A1 - A5: bool
 - B1 - B3: bool
 - samplerate: int, (22050, 24000, 32000, 44100, 48000, 88200, 96000, 176400, 192000)
@@ -540,6 +534,13 @@ The following commands are available:
 
 The following methods are available:
 
+- Play()
+- Stop()
+- Replay()
+- FF()
+- Rew()
+- Record()
+- Pause()
 - Load($filepath): string
 - GoTo($timestring): string, must match the format 'hh:mm:ss'
 - FileType($format): string, ('wav', 'aiff', 'bwf', 'mp3')
@@ -547,7 +548,7 @@ The following methods are available:
 example:
 
 ```powershell
-$vmr.recorder.play
+$vmr.recorder.play()
 $vmr.recorder.A1 = $true
 
 $vmr.recorder.GoTo("00:01:15")  # go to 1min 15sec into track

--- a/lib/arraymember.ps1
+++ b/lib/arraymember.ps1
@@ -25,7 +25,7 @@ class BoolArrayMember : ArrayMember {
     ) : base ($index, $prefix, $parent) {}
     
     [bool] Get () {
-        return [bool]$this.Getter('')
+        return $this.Getter('')
     }
 }
 
@@ -35,7 +35,7 @@ class IntArrayMember : ArrayMember {
     ) : base ($index, $prefix, $parent) {}
     
     [int] Get () {
-        return [int]$this.Getter('')
+        return $this.Getter('')
     }
 }
 
@@ -59,6 +59,6 @@ class StringArrayMember : ArrayMember {
     ) : base ($index, $prefix, $parent) {}
     
     [string] Get () {
-        return [string]$this.Getter_String('')
+        return $this.Getter_String('')
     }
 }

--- a/lib/device.ps1
+++ b/lib/device.ps1
@@ -25,7 +25,7 @@ class Device : IRemote {
             return Write-Warning ("ERROR: $($this.identifier()).wdm is write only")
         } `
         {
-            param($arg)
+            param([string]$arg)
             return $this.Setter('wdm', $arg)
         }
     )
@@ -35,7 +35,7 @@ class Device : IRemote {
             return Write-Warning ("ERROR: $($this.identifier()).ks is write only")
         } `
         {
-            param($arg)
+            param([string]$arg)
             return $this.Setter('ks', $arg)
         }
     )
@@ -45,7 +45,7 @@ class Device : IRemote {
             return Write-Warning ("ERROR: $($this.identifier()).mme is write only")
         } `
         {
-            param($arg)
+            param([string]$arg)
             return $this.Setter('mme', $arg)
         }
     )

--- a/lib/meta.ps1
+++ b/lib/meta.ps1
@@ -66,14 +66,10 @@ function AddActionMembers () {
     param(
         [String[]]$PARAMS
     )
-    [hashtable]$Signatures = @{}
     foreach ($param in $PARAMS) {
-        # Define getter
-        $Signatures['Getter'] = "`$this.Setter('{0}', `$true)" -f $param
-        # Define setter
-        $Signatures['Setter'] = ''
-
-        Addmember
+        $this | Add-Member -MemberType ScriptMethod -Name $param `
+            -Value ([scriptblock]::Create("`$null = `$this.Setter('$param', 1)")) `
+            -Force
     }
 }
 

--- a/lib/meta.ps1
+++ b/lib/meta.ps1
@@ -7,7 +7,7 @@ function AddBoolMembers () {
         # Define getter
         $Signatures['Getter'] = "[bool]`$this.Getter('{0}')" -f $param
         # Define setter
-        $Signatures['Setter'] = "param ( [Single]`$arg )`n`$this.Setter('{0}', `$arg)" `
+        $Signatures['Setter'] = "param ( [bool]`$arg )`n`$this.Setter('{0}', `$arg)" `
             -f $param
 
         Addmember
@@ -39,7 +39,7 @@ function AddIntMembers () {
         # Define getter
         $Signatures['Getter'] = "[Int]`$this.Getter('{0}')" -f $param
         # Define setter
-        $Signatures['Setter'] = "param ( [Single]`$arg )`n`$this.Setter('{0}', `$arg)" `
+        $Signatures['Setter'] = "param ( [Int]`$arg )`n`$this.Setter('{0}', `$arg)" `
             -f $param
 
         Addmember

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -119,7 +119,7 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
         Context 'Vban' {
             It 'Should set and get Vban.enable' {
                 $vmr.vban.enable = $value
-                $vmr.command.restart
+                $vmr.command.restart()
                 Start-Sleep -Milliseconds 2000
                 $vmr.vban.enable | Should -Be $expected
             }
@@ -214,14 +214,14 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
         Context 'Option' {
             It 'Should set and get Option.monitoronsel' -Skip:$ifNotPotato {
                 $vmr.option.monitoronsel = $value
-                $vmr.command.restart
+                $vmr.command.restart()
                 Start-Sleep -Milliseconds 2000
                 $vmr.option.monitoronsel | Should -Be $value
             }
             
             It 'Should set and get Option.slidermode' -Skip:$ifNotPotato {
                 $vmr.option.slidermode = $value
-                $vmr.command.restart
+                $vmr.command.restart()
                 Start-Sleep -Milliseconds 2000
                 $vmr.option.slidermode | Should -Be $value
             }
@@ -361,7 +361,7 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 @{ Value = 486.57 }, @{ Value = 26.41 }
             ) {
                 $vmr.option.delay[$phys_out].set($value)
-                $vmr.command.restart
+                $vmr.command.restart()
                 Start-Sleep -Milliseconds 2000
                 $vmr.option.delay[$phys_out].get() | Should -Be $value
             }
@@ -452,7 +452,7 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 @{ Value = 65535; Expected = 65535 }
             ) {
                 $vmr.vban.port = $value
-                $vmr.command.restart
+                $vmr.command.restart()
                 Start-Sleep -Milliseconds 2000
                 $vmr.vban.port | Should -Be $expected
             }
@@ -465,7 +465,7 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                     @{ Value = 65535; Expected = 65535 }
                 ) {
                     $vmr.vban.instream[$index].port = $value
-                    $vmr.command.restart
+                    $vmr.command.restart()
                     Start-Sleep -Milliseconds 2000
                     $vmr.vban.instream[$index].port | Should -Be $expected
                 }
@@ -508,7 +508,7 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                     @{ Value = 65535; Expected = 65535 }
                 ) {
                     $vmr.vban.outstream[$index].port = $value
-                    $vmr.command.restart
+                    $vmr.command.restart()
                     Start-Sleep -Milliseconds 2000
                     $vmr.vban.outstream[$index].port | Should -Be $expected
                 }


### PR DESCRIPTION
## What

Changes AddActionMembers to add `ScriptMethod` members instead of `ScriptProperty` members. This is a breaking change.
Makes some small type adjustments for clarity and consistency.

### Affected members
```powershell
$vmr.command.show()
$vmr.command.restart()
$vmr.command.shutdown()

$vmr.recorder.play()
$vmr.recorder.stop()
$vmr.recorder.replay()
$vmr.recorder.ff()
$vmr.recorder.rew()
$vmr.recorder.record()
$vmr.recorder.pause()
```

### Types

- `AddBoolMembers` and `AddIntMembers` $arg types
- explicit Device $arg types
- removed redundant casting of ArrayMember getters

## Testing/Notes

Pester tests pass for all kinds for safety, but most of this needed manual testing.
Manual tests pass for all kinds.

Further related changes, among others, to Recorder and Command will come in their own PRs.