### PR TITLE
Recorder commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ AddActionMembers now adds ScriptMethods instead of ScriptProperties:
 - Recorder.PreRecTime
 - Recorder.Prefix($prefix)
 - Recorder.Eject() references 'Command.Eject'
+- Recorder.State
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ AddActionMembers now adds ScriptMethods instead of ScriptProperties:
 - Recorder.Armedbus
 - Recorder.PreRecTime
 - Recorder.Prefix($prefix)
+- Recorder.Eject() references 'Command.Eject'
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ AddActionMembers now adds ScriptMethods instead of ScriptProperties:
 - See Recorder section of README for details on using playback/record actions
 
 Deprecated Recorder.Loop removed: use Recorder.Mode.Loop
+Recorder.FileType changed from method to write-only property
 
 ### Added
 
@@ -35,7 +36,7 @@ Deprecated Recorder.Loop removed: use Recorder.Mode.Loop
 - Bus.Mode.Set($mode)
 - Recorder.Armedbus
 - Recorder.PreRecTime
-- Recorder.Prefix($prefix)
+- Recorder.Prefix
 - Recorder.Eject() references 'Command.Eject'
 - Recorder.State
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Deprecated Recorder.Loop removed: use Recorder.Mode.Loop
 - Meta: AddBoolMembers, AddIntMembers $arg types for consistency
 - Device: explicit $arg types for consistency
 - Recorder.Armstrip|Armbus -> BoolArrayMember: now have .Get()
+- Cast Recorder getters to types for consistency
 
 ### Fixed
 
@@ -61,6 +62,7 @@ Deprecated Recorder.Loop removed: use Recorder.Mode.Loop
 - vban.stream.port: [string]$arg -> [int]$arg
 - vban route range (API documentation is incorrect)
 - vban.stream.sr: $this._port -> $this._sr
+- Recorder.channel values: 1..8 -> (2, 4, 6, 8)
 
 ## [3.3.0] - 2024-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ AddActionMembers now adds ScriptMethods instead of ScriptProperties:
   - ip, write-only
 - Bus.Sel, Bus.Monitor, Bus.Vaio
 - Bus.Mode.Set($mode)
+- Recorder.Armedbus
 
 ### Changed
 
@@ -43,6 +44,7 @@ AddActionMembers now adds ScriptMethods instead of ScriptProperties:
 - Bus.Levels.Convert return type [float] -> [single] for naming consistency, no functional change
 - Meta: AddBoolMembers, AddIntMembers $arg types for consistency
 - Device: explicit $arg types for consistency
+- Recorder.Armstrip|Armbus -> BoolArrayMember: now have .Get()
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ AddActionMembers now adds ScriptMethods instead of ScriptProperties:
 - See Command section of README for details on using special commands
 - See Recorder section of README for details on using playback/record actions
 
+Deprecated Recorder.Loop removed: use Recorder.Mode.Loop
+
 ### Added
 
 - IRemote base class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ AddActionMembers now adds ScriptMethods instead of ScriptProperties:
 - Bus.Sel, Bus.Monitor, Bus.Vaio
 - Bus.Mode.Set($mode)
 - Recorder.Armedbus
+- Recorder.PreRecTime
+- Recorder.Prefix($prefix)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ The following commands are available:
 
 - A1 - A5: bool
 - B1 - B3: bool
+- armedbus: int, from 0 to bus index
 - samplerate: int, (22050, 24000, 32000, 44100, 48000, 88200, 96000, 176400, 192000)
 - bitresolution: int, (8, 16, 24, 32)
 - channel: int, from 1 to 8
@@ -571,9 +572,10 @@ $vmr.recorder.mode.loop = $true
 
 #### ArmStrip[i]|ArmBus[i]
 
-The following method is available:
+The following methods are available:
 
 - Set($val): bool
+- Get()
 
 example:
 

--- a/README.md
+++ b/README.md
@@ -531,6 +531,8 @@ The following commands are available:
 - armedbus: int, from 0 to bus index
 - state: string, ('play', 'stop', 'record', 'pause')
 - prerectime: int, from 0 to 20 seconds
+- prefix: string, write-only
+- filetype: string, write-only, ('wav', 'aiff', 'bwf', 'mp3')
 - samplerate: int, (22050, 24000, 32000, 44100, 48000, 88200, 96000, 176400, 192000)
 - bitresolution: int, (8, 16, 24, 32)
 - channel: int, (2, 4, 6, 8)
@@ -548,8 +550,6 @@ The following methods are available:
 - Eject()
 - Load($filepath): string
 - GoTo($timestring): string, must match the format 'hh:mm:ss'
-- FileType($format): string, ('wav', 'aiff', 'bwf', 'mp3')
-- Prefix($prefix): string
 
 example:
 

--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ The following commands are available:
 - A1 - A5: bool
 - B1 - B3: bool
 - armedbus: int, from 0 to bus index
+- state: string, ('play', 'stop', 'record', 'pause')
 - prerectime: int, from 0 to 20 seconds
 - samplerate: int, (22050, 24000, 32000, 44100, 48000, 88200, 96000, 176400, 192000)
 - bitresolution: int, (8, 16, 24, 32)

--- a/README.md
+++ b/README.md
@@ -543,6 +543,7 @@ The following methods are available:
 - Rew()
 - Record()
 - Pause()
+- Eject()
 - Load($filepath): string
 - GoTo($timestring): string, must match the format 'hh:mm:ss'
 - FileType($format): string, ('wav', 'aiff', 'bwf', 'mp3')

--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ The following commands are available:
 - A1 - A5: bool
 - B1 - B3: bool
 - armedbus: int, from 0 to bus index
+- prerectime: int, from 0 to 20 seconds
 - samplerate: int, (22050, 24000, 32000, 44100, 48000, 88200, 96000, 176400, 192000)
 - bitresolution: int, (8, 16, 24, 32)
 - channel: int, from 1 to 8
@@ -545,6 +546,7 @@ The following methods are available:
 - Load($filepath): string
 - GoTo($timestring): string, must match the format 'hh:mm:ss'
 - FileType($format): string, ('wav', 'aiff', 'bwf', 'mp3')
+- Prefix($prefix): string
 
 example:
 

--- a/README.md
+++ b/README.md
@@ -527,12 +527,13 @@ The following commands are available:
 
 - A1 - A5: bool
 - B1 - B3: bool
+- gain: float, from -60.0 to 12.0
 - armedbus: int, from 0 to bus index
 - state: string, ('play', 'stop', 'record', 'pause')
 - prerectime: int, from 0 to 20 seconds
 - samplerate: int, (22050, 24000, 32000, 44100, 48000, 88200, 96000, 176400, 192000)
 - bitresolution: int, (8, 16, 24, 32)
-- channel: int, from 1 to 8
+- channel: int, (2, 4, 6, 8)
 - kbps: int, (32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320)
 
 The following methods are available:

--- a/lib/recorder.ps1
+++ b/lib/recorder.ps1
@@ -71,7 +71,7 @@ class Recorder : IRemote {
 
     hidden $_samplerate = $($this | Add-Member ScriptProperty 'samplerate' `
         {
-            $this.Getter('samplerate')
+            [int]$this.Getter('samplerate')
         } `
         {
             param([int]$arg)
@@ -87,7 +87,7 @@ class Recorder : IRemote {
 
     hidden $_bitresolution = $($this | Add-Member ScriptProperty 'bitresolution' `
         {
-            $this.Getter('bitresolution')
+            [int]$this.Getter('bitresolution')
         } `
         {
             param([int]$arg)
@@ -103,22 +103,23 @@ class Recorder : IRemote {
 
     hidden $_channel = $($this | Add-Member ScriptProperty 'channel' `
         {
-            $this.Getter('channel')
+            [int]$this.Getter('channel')
         } `
         {
             param([int]$arg)
-            if ($arg -ge 1 -and $arg -le 8) {
+            $opts = @(2, 4, 6, 8)
+            if ($opts.Contains($arg)) {
                 $this._channel = $this.Setter('channel', $arg)
             }
             else {
-                "channel got: $arg, expected value from 1 to 8" | Write-Warning
+                "channel got: $arg, expected one of $opts" | Write-Warning
             }
         }
     )
 
     hidden $_kbps = $($this | Add-Member ScriptProperty 'kbps' `
         {
-            $this.Getter('kbps')
+            [int]$this.Getter('kbps')
         } `
         {
             param([int]$arg)

--- a/lib/recorder.ps1
+++ b/lib/recorder.ps1
@@ -154,6 +154,10 @@ class Recorder : IRemote {
     [void] Prefix ([string]$prefix) {
         $this.Setter('prefix', $prefix)
     }
+
+    [void] Eject () {
+        $this.remote.Setter('Command.Eject', 1)
+    }
 }
 
 class RecorderMode : IRemote {

--- a/lib/recorder.ps1
+++ b/lib/recorder.ps1
@@ -2,6 +2,7 @@ class Recorder : IRemote {
     [Object]$mode
     [System.Collections.ArrayList]$armstrip
     [System.Collections.ArrayList]$armbus
+    [System.Collections.ArrayList]$states
 
     Recorder ([Object]$remote) : base ($remote) {
         $this.mode = [RecorderMode]::new($remote)
@@ -18,8 +19,10 @@ class Recorder : IRemote {
             $this.armbus.Add([BoolArrayMember]::new($i, 'armbus', $this))
         }
 
-        AddActionMembers -PARAMS @('play', 'stop', 'pause', 'replay', 'record', 'ff', 'rew')
-        
+        $this.states = @('play', 'stop', 'record', 'pause')
+        AddActionMembers -PARAMS $this.states
+
+        AddActionMembers -PARAMS @('replay', 'ff', 'rew')
         AddFloatMembers -PARAMS @('gain')
         AddIntMembers -PARAMS @('prerectime')
 
@@ -121,7 +124,32 @@ class Recorder : IRemote {
             else {
                 Write-Warning ("Expected a bus index between 0 and $busMax")
             }
-        })
+        }
+    )
+
+    hidden $_state = $($this | Add-Member ScriptProperty 'state' `
+        {
+            if ($this.Getter('pause')) { return 'pause' }
+            foreach ($state in $this.states) {
+                if ($this.Getter($state)) {
+                    break
+                }
+            }
+            return $state
+        } `
+        {
+            param([string]$arg)
+            if (-not $this.states.Contains($arg)) {
+                Write-Warning ("Recorder.State got: $arg, expected one of $($this.states)")
+                return
+            }
+            if ($arg -eq 'pause' -and -not $this.Getter('record')) {
+                Write-Warning ("Recorder.State can only be set to 'pause' when recording")
+                return
+            }
+            $this._state = $this.Setter($arg, 1)
+        }
+    )
 
     [void] Load ([string]$filename) {
         $this.Setter('load', $filename)

--- a/lib/recorder.ps1
+++ b/lib/recorder.ps1
@@ -41,22 +41,6 @@ class Recorder : IRemote {
         $this.Setter('load', $filename)
     }
 
-    [void] Prefix ([string]$prefix) {
-        $this.Setter('prefix', $prefix)
-    }
-
-    [void] FileType([string]$format) {
-        [int]$val = 0
-        switch ($format) {
-            'wav' { $val = 1 }
-            'aiff' { $val = 2 }
-            'bwf' { $val = 3 }
-            'mp3' { $val = 100 }
-            default { "Filetype() got: $format, expected one of 'wav', 'aiff', 'bwf', 'mp3'" }
-        }
-        $this.Setter('filetype', $val)
-    }
-
     [void] GoTo ([string]$timestring) {
         try {
             if ([datetime]::ParseExact($timestring, 'HH:mm:ss', $null)) {
@@ -130,6 +114,34 @@ class Recorder : IRemote {
             else {
                 "kbps got: $arg, expected one of $opts" | Write-Warning
             }
+        }
+    )
+
+    hidden $_prefix = $($this | Add-Member ScriptProperty 'prefix' `
+        {
+            return Write-Warning ("ERROR: $($this.identifier()).prefix is write only")
+        } `
+        {
+            param([string]$arg)
+            $this._prefix = $this.Setter('prefix', $arg)
+        }
+    )
+
+    hidden $_filetype = $($this | Add-Member ScriptProperty 'filetype' `
+        {
+            return Write-Warning ("ERROR: $($this.identifier()).filetype is write only")
+        } `
+        {
+            param([string]$arg)
+            [int]$val = 0
+            switch ($arg) {
+                'wav' { $val = 1 }
+                'aiff' { $val = 2 }
+                'bwf' { $val = 3 }
+                'mp3' { $val = 100 }
+                default { "Filetype() got: $arg, expected one of 'wav', 'aiff', 'bwf', 'mp3'" }
+            }
+            $this._filetype = $this.Setter('filetype', $val)
         }
     )
 

--- a/lib/recorder.ps1
+++ b/lib/recorder.ps1
@@ -19,7 +19,10 @@ class Recorder : IRemote {
         }
 
         AddActionMembers -PARAMS @('play', 'stop', 'pause', 'replay', 'record', 'ff', 'rew')
+        
         AddFloatMembers -PARAMS @('gain')
+        AddIntMembers -PARAMS @('prerectime')
+
         AddChannelMembers
     }
 
@@ -146,6 +149,10 @@ class Recorder : IRemote {
             default { "Filetype() got: $format, expected one of 'wav', 'aiff', 'bwf', 'mp3'" }
         }
         $this.Setter('filetype', $val)
+    }
+
+    [void] Prefix ([string]$prefix) {
+        $this.Setter('prefix', $prefix)
     }
 }
 

--- a/lib/recorder.ps1
+++ b/lib/recorder.ps1
@@ -5,13 +5,17 @@ class Recorder : IRemote {
 
     Recorder ([Object]$remote) : base ($remote) {
         $this.mode = [RecorderMode]::new($remote)
+        
         $this.armstrip = @()
-        0..($remote.kind.p_in + $remote.kind.v_in - 1) | ForEach-Object {
-            $this.armstrip.Add([RecorderArmStrip]::new($_, $remote))
+        $stripCount = $($remote.kind.p_in + $remote.kind.v_in)
+        for ($i = 0; $i -lt $stripCount; $i++) {
+            $this.armstrip.Add([BoolArrayMember]::new($i, 'armstrip', $this))
         }
+        
         $this.armbus = @()
-        0..($remote.kind.p_out + $remote.kind.v_out - 1) | ForEach-Object {
-            $this.armbus.Add([RecorderArmBus]::new($_, $remote))
+        $busCount = $($remote.kind.p_out + $remote.kind.v_out)
+        for ($i = 0; $i -lt $busCount; $i++) {
+            $this.armbus.Add([BoolArrayMember]::new($i, 'armbus', $this))
         }
 
         AddActionMembers -PARAMS @('play', 'stop', 'pause', 'replay', 'record', 'ff', 'rew')
@@ -95,6 +99,26 @@ class Recorder : IRemote {
             }
         }
     )
+
+    hidden $_armedbus = $($this | Add-Member ScriptProperty 'armedbus' `
+        {
+            foreach ($bus in 0..$($this.remote.kind.p_out + $this.remote.kind.v_out - 1)) {
+                if ($this.remote.Getter("Recorder.ArmBus[$bus]")) {
+                    break
+                }
+            }
+            return $bus
+        } `
+        {
+            param([int]$arg)
+            $busMax = $this.remote.kind.p_out + $this.remote.kind.v_out - 1
+            if ($arg -ge 0 -and $arg -le $busMax) {
+                $this._armedbus = $this.remote.Setter("Recorder.ArmBus[$arg]", 1)
+            }
+            else {
+                Write-Warning ("Expected a bus index between 0 and $busMax")
+            }
+        })
 
     [void] Load ([string]$filename) {
         $this.Setter('load', $filename)

--- a/lib/recorder.ps1
+++ b/lib/recorder.ps1
@@ -33,15 +33,41 @@ class Recorder : IRemote {
         return 'Recorder'
     }
 
-    hidden $_loop = $($this | Add-Member ScriptProperty 'loop' `
-        {
-            [bool]$this.mode.loop
-        } `
-        {
-            param($arg)
-            $this.mode.loop = $arg
+    [void] Eject () {
+        $this.remote.Setter('Command.Eject', 1)
+    }
+
+    [void] Load ([string]$filename) {
+        $this.Setter('load', $filename)
+    }
+
+    [void] Prefix ([string]$prefix) {
+        $this.Setter('prefix', $prefix)
+    }
+
+    [void] FileType([string]$format) {
+        [int]$val = 0
+        switch ($format) {
+            'wav' { $val = 1 }
+            'aiff' { $val = 2 }
+            'bwf' { $val = 3 }
+            'mp3' { $val = 100 }
+            default { "Filetype() got: $format, expected one of 'wav', 'aiff', 'bwf', 'mp3'" }
         }
-    )
+        $this.Setter('filetype', $val)
+    }
+
+    [void] GoTo ([string]$timestring) {
+        try {
+            if ([datetime]::ParseExact($timestring, 'HH:mm:ss', $null)) {
+                $timespan = [timespan]::Parse($timestring)
+                $this.Setter('GoTo', $timespan.TotalSeconds)                
+            }
+        }
+        catch [FormatException] {
+            "Time string $timestring does not match the required format 'hh:mm:ss'" | Write-Warning
+        }
+    }
 
     hidden $_samplerate = $($this | Add-Member ScriptProperty 'samplerate' `
         {
@@ -150,42 +176,6 @@ class Recorder : IRemote {
             $this._state = $this.Setter($arg, 1)
         }
     )
-
-    [void] Load ([string]$filename) {
-        $this.Setter('load', $filename)
-    }
-
-    [void] GoTo ([string]$timestring) {
-        try {
-            if ([datetime]::ParseExact($timestring, 'HH:mm:ss', $null)) {
-                $timespan = [timespan]::Parse($timestring)
-                $this.Setter('GoTo', $timespan.TotalSeconds)                
-            }
-        }
-        catch [FormatException] {
-            "Time string $timestring does not match the required format 'hh:mm:ss'" | Write-Warning
-        }
-    }
-
-    [void] FileType($format) {
-        [int]$val = 0
-        switch ($format) {
-            'wav' { $val = 1 }
-            'aiff' { $val = 2 }
-            'bwf' { $val = 3 }
-            'mp3' { $val = 100 }
-            default { "Filetype() got: $format, expected one of 'wav', 'aiff', 'bwf', 'mp3'" }
-        }
-        $this.Setter('filetype', $val)
-    }
-
-    [void] Prefix ([string]$prefix) {
-        $this.Setter('prefix', $prefix)
-    }
-
-    [void] Eject () {
-        $this.remote.Setter('Command.Eject', 1)
-    }
 }
 
 class RecorderMode : IRemote {
@@ -195,33 +185,6 @@ class RecorderMode : IRemote {
 
     [string] identifier () {
         return 'Recorder.Mode'
-    }
-}
-
-class RecorderArm : IRemote {
-    RecorderArm ([int]$index, [Object]$remote) : base ($index, $remote) {
-    }
-
-    Set ([bool]$val) {
-        $this.Setter('', $(if ($val) { 1 } else { 0 }))
-    }
-}
-
-class RecorderArmStrip : RecorderArm {
-    RecorderArmStrip ([int]$index, [Object]$remote) : base ($index, $remote) {
-    }
-
-    [string] identifier () {
-        return "Recorder.ArmStrip[$($this.index)]"
-    }
-}
-
-class RecorderArmBus : RecorderArm {
-    RecorderArmBus ([int]$index, [Object]$remote) : base ($index, $remote) {
-    }
-
-    [string] identifier () {
-        return "Recorder.ArmBus[$($this.index)]"
     }
 }
 

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -910,8 +910,8 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 try {
                     $prefix = 'stringtest'
                     $filetype = 'wav'
-                    $vmr.recorder.prefix($prefix)
-                    $vmr.recorder.filetype($filetype)
+                    $vmr.recorder.prefix = $prefix
+                    $vmr.recorder.filetype = $filetype
 
                     $vmr.recorder.state = 'record'
                     $stamp = '{0:yyyy-MM-dd} at {0:HH}h{0:mm}m{0:ss}s' -f (Get-Date)
@@ -956,8 +956,8 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 BeforeAll {
                     $prefix = 'actiontest'
                     $filetype = 'wav'
-                    $vmr.recorder.prefix($prefix)
-                    $vmr.recorder.filetype($filetype)
+                    $vmr.recorder.prefix = $prefix
+                    $vmr.recorder.filetype = $filetype
                 }
 
                 BeforeEach {

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -160,6 +160,20 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             It 'Should set and get Recorder.loop' {
                 $vmr.recorder.loop = $value
             }
+
+            It 'Should set and get Recorder.armstrip[i]' -ForEach @(
+                @{ Index = $phys_in }, @{ Index = $virt_in }
+            ) {
+                $vmr.recorder.armstrip[$index].set($value)
+                $vmr.recorder.armstrip[$index].get() | Should -Be $value
+            }
+
+            It 'Should set and get Recorder.armbus[i]' -ForEach @(
+                @{ Index = $phys_out }, @{ Index = $virt_out }
+            ) {
+                $vmr.recorder.armbus[$index].set($value)
+                $vmr.recorder.armbus[$index].get() | Should -Be $value
+            }
         }
 
         Context 'Command' {
@@ -601,6 +615,15 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                     Start-Sleep -Milliseconds 500
                     $vmr.option.buffer.ks | Should -Be $value
                 }
+            }
+        }
+
+        Context 'Recorder' -Skip:$ifBasic {
+            It 'Should set and get Recorder.armedbus' -ForEach @(
+                @{ Value = $phys_out }, @{ Value = $virt_out }
+            ) {
+                $vmr.recorder.armedbus = $value
+                $vmr.recorder.armedbus | Should -Be $value
             }
         }
     }

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -640,6 +640,27 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 $vmr.recorder.prerectime = $value
                 $vmr.recorder.prerectime | Should -Be $value
             }
+
+            It 'Should set and get Recorder.samplerate' -ForEach @(
+                @{ Value = 44100 }, @{ Value = 48000 }
+            ) {
+                $vmr.recorder.samplerate = $value
+                $vmr.recorder.samplerate | Should -Be $value
+            }
+
+            It 'Should set and get Recorder.bitresolution' -ForEach @(
+                @{ Value = 24 }, @{ Value = 16 }
+            ) {
+                $vmr.recorder.bitresolution = $value
+                $vmr.recorder.bitresolution | Should -Be $value
+            }
+
+            It 'Should set and get Recorder.kbps' -ForEach @(
+                @{ Value = 96 }, @{ Value = 192 }
+            ) {
+                $vmr.recorder.kbps = $value
+                $vmr.recorder.kbps | Should -Be $value
+            }
         }
     }
 

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -157,10 +157,6 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 $vmr.recorder.B1 | Should -Be $expected
             }
 
-            It 'Should set and get Recorder.loop' {
-                $vmr.recorder.loop = $value
-            }
-
             It 'Should set and get Recorder.armstrip[i]' -ForEach @(
                 @{ Index = $phys_in }, @{ Index = $virt_in }
             ) {
@@ -173,6 +169,18 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             ) {
                 $vmr.recorder.armbus[$index].set($value)
                 $vmr.recorder.armbus[$index].get() | Should -Be $value
+            }
+
+            Context 'Mode' {
+                It 'Should set and get Recorder.mode.multitrack' {
+                    $vmr.recorder.mode.multitrack = $value
+                    $vmr.recorder.mode.multitrack | Should -Be $expected
+                }
+
+                It 'Should set and get Recorder.mode.loop' {
+                    $vmr.recorder.mode.loop = $value
+                    $vmr.recorder.mode.loop | Should -Be $expected
+                }
             }
         }
 

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -876,4 +876,60 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             }
         }
     }
+
+    Describe 'Action Tests' -Tag 'action' {
+        Context 'Recorder' -Skip:$ifBasic {
+            Context 'Recording/Playback' -Skip:$ifCustomDir {
+                BeforeAll {
+                    $prefix = 'temp'
+                    $filetype = 'wav'
+                    $vmr.recorder.prefix($prefix)
+                    $vmr.recorder.filetype($filetype)
+                }
+
+                BeforeEach {
+                    $vmr.recorder.state = 'record'
+                    $stamp = '{0:yyyy-MM-dd} at {0:HH}h{0:mm}m{0:ss}s' -f (Get-Date)
+                    Start-Sleep -Milliseconds 2000
+
+                    $tmp = [System.IO.Path]::Combine($recDir, ("{0} {1}.{2}" -f $prefix, $stamp, $filetype))
+
+                    $vmr.recorder.state = 'pause'
+                    Start-Sleep -Milliseconds 500
+                }
+
+                AfterEach {
+                    $vmr.recorder.state = 'stop'
+                    $vmr.recorder.eject()
+                    Start-Sleep -Milliseconds 500
+                    
+                    if (Test-Path $tmp) {
+                        Remove-Item -Path $tmp -Force
+                    }
+                    else {
+                        throw "Recording file $tmp was not found."
+                    }
+                }
+            
+                It 'Should call Recorder.record()' {
+                    $vmr.recorder.record()
+                    $vmr.recorder.state | Should -Be 'record'
+                }
+
+                It 'Should call Recorder.pause()' {
+                    $vmr.recorder.record()
+                    Start-Sleep -Milliseconds 500
+                    $vmr.recorder.pause()
+                    $vmr.recorder.state | Should -Be 'pause'
+                }
+
+                It 'Should call Recorder.play()' {
+                    $vmr.recorder.stop()
+                    Start-Sleep -Milliseconds 500
+                    $vmr.recorder.play()
+                    $vmr.recorder.state | Should -Be 'play'
+                }
+            }
+        }
+    }
 }

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -625,6 +625,13 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 $vmr.recorder.armedbus = $value
                 $vmr.recorder.armedbus | Should -Be $value
             }
+
+            It 'Should set and get Recorder.prerectime' -ForEach @(
+                @{ Value = 5 }, @{ Value = 20 }
+            ) {
+                $vmr.recorder.prerectime = $value
+                $vmr.recorder.prerectime | Should -Be $value
+            }
         }
     }
 

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -875,31 +875,75 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 }       
             }
         }
+
+        Context 'Recorder' -Skip:$ifBasic {
+            It 'Should record a test file, eject, and load it back' -Skip:$ifCustomDir {
+                try {
+                    $prefix = 'stringtest'
+                    $filetype = 'wav'
+                    $vmr.recorder.prefix($prefix)
+                    $vmr.recorder.filetype($filetype)
+
+                    $vmr.recorder.state = 'record'
+                    $stamp = '{0:yyyy-MM-dd} at {0:HH}h{0:mm}m{0:ss}s' -f (Get-Date)
+                    $vmr.recorder.state | Should -Be 'record'
+                    Start-Sleep -Milliseconds 2000
+
+                    $tmp = [System.IO.Path]::Combine($recDir, ("{0} {1}.{2}" -f $prefix, $stamp, $filetype))
+
+                    $vmr.recorder.state = 'stop'
+                    $vmr.recorder.eject()
+                    Start-Sleep -Milliseconds 500
+
+                    $vmr.recorder.state = 'play'
+                    $vmr.recorder.state | Should -Be 'stop'  # because no file is loaded
+
+                    $vmr.recorder.load($tmp)
+                    Start-Sleep -Milliseconds 500
+                    if (-not $vmr.recorder.mode.playonload) {
+                        $vmr.recorder.state = 'play'
+                    }
+                    $vmr.recorder.state | Should -Be 'play'
+                }
+                finally {
+                    $vmr.recorder.state = 'stop'
+                    $vmr.recorder.eject()
+                    Start-Sleep -Milliseconds 500
+                    
+                    if (Test-Path $tmp) {
+                        Remove-Item -Path $tmp -Force
+                    }
+                    else {
+                        throw "Recording file $tmp was not found."
+                    }
+                }
+            }
+        }
     }
 
     Describe 'Action Tests' -Tag 'action' {
         Context 'Recorder' -Skip:$ifBasic {
             Context 'Recording/Playback' -Skip:$ifCustomDir {
                 BeforeAll {
-                    $prefix = 'temp'
+                    $prefix = 'actiontest'
                     $filetype = 'wav'
                     $vmr.recorder.prefix($prefix)
                     $vmr.recorder.filetype($filetype)
                 }
 
                 BeforeEach {
-                    $vmr.recorder.state = 'record'
+                    $vmr.recorder.record()
                     $stamp = '{0:yyyy-MM-dd} at {0:HH}h{0:mm}m{0:ss}s' -f (Get-Date)
                     Start-Sleep -Milliseconds 2000
 
                     $tmp = [System.IO.Path]::Combine($recDir, ("{0} {1}.{2}" -f $prefix, $stamp, $filetype))
 
-                    $vmr.recorder.state = 'pause'
+                    $vmr.recorder.pause()
                     Start-Sleep -Milliseconds 500
                 }
 
                 AfterEach {
-                    $vmr.recorder.state = 'stop'
+                    $vmr.recorder.stop()
                     $vmr.recorder.eject()
                     Start-Sleep -Milliseconds 500
                     

--- a/tests/run.ps1
+++ b/tests/run.ps1
@@ -1,7 +1,40 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Target = "variablename")]
-Param([String]$tag, [string]$kind = 'potato')
+Param([String]$tag, [string]$kind = 'potato', [string]$recDir = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Voicemeeter'))
 Import-Module (Join-Path (Split-Path $PSScriptRoot -Parent) 'lib\Voicemeeter.psm1') -Force
 
+
+function Test-RecDir ([object]$vmr, [string]$recDir) {
+    $prefix = 'temp'
+    $filetype = 'wav'
+    $vmr.recorder.prefix($prefix)
+    $vmr.recorder.filetype($filetype)
+
+    
+    try {
+        $vmr.recorder.record()
+        $stamp = '{0:yyyy-MM-dd} at {0:HH}h{0:mm}m{0:ss}s' -f (Get-Date)
+        Start-Sleep -Milliseconds 2000
+
+        $tmp = Join-Path $recDir ("{0} {1}.{2}" -f $prefix, $stamp, $filetype)
+
+        $vmr.recorder.stop()
+        $vmr.recorder.eject()
+        Start-Sleep -Milliseconds 500
+    }
+    catch {
+        Write-Warning "Failed to record pre-check clip: $_"
+    }
+
+    if (Test-Path $tmp) {
+        Remove-Item -Path $tmp -Force
+        return $false
+    }
+    else {
+        Write-Warning "Recorder output not found at given path: $tmp"
+        Write-Warning "Skipping Recording/Playback tests. Provide custom path with -recDir"
+        return $true
+    }
+}
 
 function main() {
     try {
@@ -29,6 +62,10 @@ function main() {
         $ifBasic = $vmr.kind.name -eq 'basic'
         $ifNotBasic = $vmr.kind.name -ne 'basic'
         $ifNotPotato = $vmr.kind.name -ne 'potato'
+
+        # recording directory: default ~/My Documents/Voicemeeter, override if custom
+        $recDir = [System.IO.Path]::GetFullPath($recDir)
+        $ifCustomDir = Test-RecDir -vmr $vmr -recDir $recDir # avoid creating files we can't delete
 
         Invoke-Pester -Tag $tag -PassThru | Out-Null
     }

--- a/tests/run.ps1
+++ b/tests/run.ps1
@@ -6,8 +6,8 @@ Import-Module (Join-Path (Split-Path $PSScriptRoot -Parent) 'lib\Voicemeeter.psm
 function Test-RecDir ([object]$vmr, [string]$recDir) {
     $prefix = 'temp'
     $filetype = 'wav'
-    $vmr.recorder.prefix($prefix)
-    $vmr.recorder.filetype($filetype)
+    $vmr.recorder.prefix = $prefix
+    $vmr.recorder.filetype = $filetype
 
     
     try {

--- a/tests/run.ps1
+++ b/tests/run.ps1
@@ -65,7 +65,12 @@ function main() {
 
         # recording directory: default ~/My Documents/Voicemeeter, override if custom
         $recDir = [System.IO.Path]::GetFullPath($recDir)
-        $ifCustomDir = Test-RecDir -vmr $vmr -recDir $recDir # avoid creating files we can't delete
+        if ($ifBasic) {
+            $ifCustomDir = $ifBasic # basic can't record, so skip the test
+        }
+        else {
+            $ifCustomDir = Test-RecDir -vmr $vmr -recDir $recDir # avoid creating files we can't delete
+        }
 
         Invoke-Pester -Tag $tag -PassThru | Out-Null
     }


### PR DESCRIPTION
Closes #22 

## What

Updates Recorder class with new commands, changes, etc.

### Add

```powershell
$vmr.recorder.eject()            # "Command.eject"
$vmr.recorder.prefix([string])
$vmr.recorder.prerectime = [int]
$vmr.recorder.state = [string]   # Sets/gets current playback/recording state 'play', 'stop', 'record', 'pause'
```

- Changes `RecorderArmStrip | RecorderArmBus -> BoolArrayMember` for:
```powershell
$vmr.recorder.armstrip[$i].get()
$vmr.recorder.armbus[$i].get()
# additionally
$vmr.recorder.armedbus = [int]   # Sets/gets currently armed bus
```

### Fixed/Changed

- accepted `channel` values: `1..8 -> (2, 4, 6, 8)`
- Cast getters to types for consistency
- Remove deprecated `$vmr.recorder.loop`: noted breaking change in CHANGELOG

## Testing/Notes

Added a recording directory test: if a custom target directory has been set but not passed to the tests, avoids creating a bunch of audio files without being able to delete them. Custom target directory can be passed with `-recDir`. Defaults to `Documents/Voicemeeter`.

Pester tests pass for all kinds.

Manual tests for safety pass for all kinds:
- channel

Also added `gain` to README.

## Questions

`Recorder.Prefix` is write-only like `FileType`, so similarly implemented as a method. If it's possible these could be read/write in the future, it may be preferable to change them to properties with a write-only warning to avoid breaking changes when that happens. If they're unlikely to change, a method should be clearer. Let me know if you prefer properties and I can make that change. Otherwise, PR is ready for review.