### PR TITLE
Special commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Recorder.FileType changed from method to write-only property
 - Recorder.Prefix
 - Recorder.Eject() references 'Command.Eject'
 - Recorder.State
+- Command.Reset()
+- Command.Save($filepath)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Recorder.FileType changed from method to write-only property
 - Recorder.State
 - Command.Reset()
 - Command.Save($filepath)
+- Command.StorePreset()
+- Command.RecallPreset()
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -428,6 +428,8 @@ The following methods are available:
 - HideVBANChat()
 - Restart()
 - Shutdown()
+- Reset(): Reset all config
+- Save($filepath): string
 - Load($filepath): string
 - RunMacrobuttons(): Launches the macrobuttons app
 - CloseMacrobuttons(): Closes the macrobuttons app
@@ -437,7 +439,7 @@ example:
 ```powershell
 $vmr.command.show()
 
-$vmr.command.lock = $true
+$vmr.command.lock()
 
 $vmr.command.Load("path/to/filename.xml")
 

--- a/README.md
+++ b/README.md
@@ -418,15 +418,14 @@ $vmr.vban.outstream[3].bit = 16
 
 Certain 'special' commands are defined by the API as performing actions rather than setting values.
 
-The following commands are available:
-
-- hide
-- showvbanchat: bool, (write only)
-- lock: bool, (write only)
-
 The following methods are available:
 
 - Show()
+- Hide()
+- Lock()
+- Unlock()
+- ShowVBANChat()
+- HideVBANChat()
 - Restart()
 - Shutdown()
 - Load($filepath): string

--- a/README.md
+++ b/README.md
@@ -431,20 +431,30 @@ The following methods are available:
 - Reset(): Reset all config
 - Save($filepath): string
 - Load($filepath): string
+- StorePreset($index, $name): (int, string)
+- RecallPreset($index or $name): (int or string)
 - RunMacrobuttons(): Launches the macrobuttons app
 - CloseMacrobuttons(): Closes the macrobuttons app
 
 example:
 
 ```powershell
-$vmr.command.show()
-
-$vmr.command.lock()
-
+$vmr.command.Show()
+$vmr.command.Lock()
 $vmr.command.Load("path/to/filename.xml")
-
 $vmr.command.RunMacrobuttons()
+
+$vmr.command.StorePreset(63, 'example')
+$vmr.command.StorePreset('example')
+$vmr.command.StorePreset(63)                # same as StorePreset(63, '')
+$vmr.command.StorePreset()                  # same as StorePreset(''), overwrites last recalled
+
+$vmr.command.RecallPreset('example')
+$vmr.command.RecallPreset(63)
+$vmr.command.RecallPreset()                 # same as RecallPreset(''), recalls last recalled
 ```
+
+StorePreset('') and RecallPreset('') interact with the 'selected' preset. This is highlighted green in the GUI. Recalling a preset selects it. Storing a preset via GUI also selects it. Storing a preset with StorePreset does not select it.
 
 ### Fx
 

--- a/lib/command.ps1
+++ b/lib/command.ps1
@@ -40,6 +40,34 @@ class Special : IRemote {
     [void] Save ([string]$filename) {
         $this.Setter('save', $filename)
     }
+
+    [void] StorePreset () {
+        $this.Setter('updatepreset', '')
+    }
+
+    [void] StorePreset ([string]$name) {
+        $this.Setter('updatepreset', $name)
+    }
+
+    [void] StorePreset ([int]$index) {
+        $this.Setter('preset[{0}].store' -f $index, '')
+    }
+
+    [void] StorePreset ([int]$index, [string]$name) {
+        $this.Setter('preset[{0}].store' -f $index, $name)
+    }
+
+    [void] RecallPreset () {
+        $this.Setter('recallpreset', '')
+    }
+
+    [void] RecallPreset ([string]$name) {
+        $this.Setter('recallpreset', $name)
+    }
+
+    [void] RecallPreset ([int]$index) {
+        $this.Setter('preset[{0}].recall' -f $index, 1)
+    }
 }
 
 function Make_Command([Object]$remote) {

--- a/lib/command.ps1
+++ b/lib/command.ps1
@@ -1,6 +1,6 @@
 class Special : IRemote {
     Special ([Object]$remote) : base ($remote) {
-        AddActionMembers -PARAMS @('restart', 'shutdown', 'show')
+        AddActionMembers -PARAMS @('restart', 'shutdown', 'show', 'lock')
     }
 
     [string] identifier () {
@@ -17,32 +17,21 @@ class Special : IRemote {
         Stop-Process -Name 'VoicemeeterMacroButtons'
     }
 
-    hidden $_hide = $($this | Add-Member ScriptProperty 'hide' `
-        {
-            $this._hide = $this.Setter('show', $false)
-        } `
-        {}
-    )
+    [void] Hide () {
+        $this.Setter('show', $false)
+    }
 
-    hidden $_showvbanchat = $($this | Add-Member ScriptProperty 'showvbanchat' `
-        {
-            $this.Getter('DialogShow.VBANCHAT')
-        } `
-        {
-            param([bool]$arg)
-            $this._showvbanchat = $this.Setter('DialogShow.VBANCHAT', $arg)
-        }
-    )
+    [void] Unlock () {
+        $this.Setter('lock', $false)
+    }
 
-    hidden $_lock = $($this | Add-Member ScriptProperty 'lock' `
-        {
-            $this._lock = $this.Getter('lock')
-        } `
-        {
-            param([bool]$arg)
-            $this._lock = $this.Setter('lock', $arg)
-        }
-    )
+    [void] ShowVBANChat () {
+        $this.Setter('DialogShow.VBANCHAT', $true)
+    }
+
+    [void] HideVBANChat () {
+        $this.Setter('DialogShow.VBANCHAT', $false)
+    }
 
     [void] Load ([string]$filename) {
         $this.Setter('load', $filename)

--- a/lib/command.ps1
+++ b/lib/command.ps1
@@ -1,6 +1,6 @@
 class Special : IRemote {
     Special ([Object]$remote) : base ($remote) {
-        AddActionMembers -PARAMS @('restart', 'shutdown', 'show', 'lock')
+        AddActionMembers -PARAMS @('restart', 'shutdown', 'show', 'lock', 'reset')
     }
 
     [string] identifier () {
@@ -35,6 +35,10 @@ class Special : IRemote {
 
     [void] Load ([string]$filename) {
         $this.Setter('load', $filename)
+    }
+
+    [void] Save ([string]$filename) {
+        $this.Setter('save', $filename)
     }
 }
 

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -184,12 +184,6 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             }
         }
 
-        Context 'Command' {
-            It 'Should set command.lock' {
-                $vmr.command.lock = $value
-            }
-        }
-
         Context 'Fx' -Skip:$ifNotPotato {
             Context 'Delay' {
                 It 'Should set and get Fx.delay.on' {
@@ -944,6 +938,51 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                     }
                     else {
                         throw "Recording file $tmp was not found."
+                    }
+                }
+            }
+        }
+
+        Context 'Command' {
+            It 'Should save, reset, then load config' -ForEach @(
+                @{ Gain = -27.1; Mode = 'composite'; Bit = 24; Port = 1044 }
+            ) {
+                $tmp = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "vmrconfig-$(New-Guid).xml")
+                try {
+                    # set some values
+                    $vmr.strip[$virt_in].gain = $gain
+                    $vmr.bus[$phys_out].mode.set($mode)
+                    $vmr.vban.outstream[$vban_outA].bit = $bit
+                    $vmr.vban.port = $port
+
+                    # save config
+                    $vmr.command.save($tmp)
+                    Start-Sleep -Milliseconds 100
+                    Test-Path $tmp | Should -BeTrue
+
+                    # reset config
+                    $vmr.command.reset()
+                    Start-Sleep -Milliseconds 500
+
+                    # verify default values
+                    $vmr.strip[$virt_in].gain | Should -Be 0.0
+                    $vmr.bus[$phys_out].mode.get() | Should -Be 'normal'
+                    $vmr.vban.outstream[$vban_outA].bit | Should -Be 16
+                    $vmr.vban.port | Should -Be 6980
+
+                    # load config
+                    $vmr.command.load($tmp)
+                    Start-Sleep -Milliseconds 500
+
+                    # verify values
+                    $vmr.strip[$virt_in].gain | Should -Be $gain
+                    $vmr.bus[$phys_out].mode.get() | Should -Be $mode
+                    $vmr.vban.outstream[$vban_outA].bit | Should -Be $bit
+                    $vmr.vban.port | Should -Be $port
+                }
+                finally {
+                    if (Test-Path $tmp) {
+                        Remove-Item $tmp -Force
                     }
                 }
             }

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -908,6 +908,7 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                     $vmr.recorder.filetype = $filetype
 
                     $vmr.recorder.state = 'record'
+                    Start-Sleep -Milliseconds 100
                     $stamp = '{0:yyyy-MM-dd} at {0:HH}h{0:mm}m{0:ss}s' -f (Get-Date)
                     $vmr.recorder.state | Should -Be 'record'
                     Start-Sleep -Milliseconds 2000
@@ -1001,6 +1002,7 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
 
                 BeforeEach {
                     $vmr.recorder.record()
+                    Start-Sleep -Milliseconds 100
                     $stamp = '{0:yyyy-MM-dd} at {0:HH}h{0:mm}m{0:ss}s' -f (Get-Date)
                     Start-Sleep -Milliseconds 2000
 
@@ -1040,6 +1042,65 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                     Start-Sleep -Milliseconds 500
                     $vmr.recorder.play()
                     $vmr.recorder.state | Should -Be 'play'
+                }
+            }
+        }
+
+        Context 'Command' {
+            Context 'Preset Scene' -ForEach @(
+                @{ Index = 0; Name = 'Test Scene 1' }
+                @{ Index = 63; Name = 'Test Scene 64' }
+            ) {
+                It "Should store preset at index '$index' with name '$name'" -ForEach @(
+                    @{ Value = -15.5 }, @{ Value = -52.9 }
+                ) {
+                    $vmr.bus[$phys_out].gain = $value
+                    $vmr.command.storepreset($index, $name)
+
+                    $vmr.bus[$phys_out].gain = 0.0
+
+                    $vmr.command.recallpreset($name)
+                    Start-Sleep -Milliseconds 500
+                    $vmr.bus[$phys_out].gain | Should -Be $value
+                }
+
+                It "Should update preset at index '$index'" -ForEach @(
+                    @{ Value = $false }, @{ Value = $true }
+                ) {
+                    $vmr.strip[$virt_in].B1 = $value
+                    $vmr.command.storepreset($index)
+
+                    $vmr.strip[$virt_in].B1 = -not $value
+
+                    $vmr.command.recallpreset($index)
+                    Start-Sleep -Milliseconds 500
+                    $vmr.strip[$virt_in].B1 | Should -Be $value
+                }
+
+                It "Should update preset with name '$name'" -ForEach @(
+                    @{ Value = 2 }, @{ Value = 1 }
+                ) {
+                    $vmr.bus[$virt_out].mono = $value
+                    $vmr.command.storepreset($name)
+
+                    $vmr.bus[$virt_out].mono = 0
+
+                    $vmr.command.recallpreset($name)
+                    Start-Sleep -Milliseconds 500
+                    $vmr.bus[$virt_out].mono | Should -Be $value
+                }
+
+                It "Should update last recalled preset ($index`: $(($index + 1).ToString('00')) - $name)" -ForEach @(
+                    @{ Value = 0.8 }, @{ Value = 0.3 }
+                ) {
+                    $vmr.strip[$phys_in].color_y = $value
+                    $vmr.command.storepreset()
+
+                    $vmr.strip[$phys_in].color_y = 0.0
+                    
+                    $vmr.command.recallpreset()
+                    Start-Sleep -Milliseconds 500
+                    $vmr.strip[$phys_in].color_y | Should -Be $value
                 }
             }
         }

--- a/tests/run.ps1
+++ b/tests/run.ps1
@@ -12,6 +12,7 @@ function Test-RecDir ([object]$vmr, [string]$recDir) {
     
     try {
         $vmr.recorder.record()
+        Start-Sleep -Milliseconds 100
         $stamp = '{0:yyyy-MM-dd} at {0:HH}h{0:mm}m{0:ss}s' -f (Get-Date)
         Start-Sleep -Milliseconds 2000
 


### PR DESCRIPTION
Closes #20 

## What

Adds new special commands and changes some write-only properties to ActionMembers/methods

### Added

```powershell
$vmr.command.reset()
$vmr.command.save([string]$filename)

# the following have multiple overloads, see README for details
$vmr.command.storepreset([int]$index, [string]$name)
$vmr.command.recallpreset([int]$index or [string]$name)
```

### Changed

`hide`, `lock`, and `showvbanchat` are now
```powershell
$vmr.command.hide()

$vmr.command.lock()
$vmr.command.unlock()

$vmr.command.showvbanchat()
$vmr.command.hidevbanchat()
```

## Testing summary

Pester tests pass for all kinds

Manual tests pass for all kinds
- show()/hide()
- lock()/unlock()
- showvbanchat()/hidevbanchat()