### PR TITLE
Float decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Recorder.FileType changed from method to write-only property
 - Device: explicit $arg types for consistency
 - Recorder.Armstrip|Armbus -> BoolArrayMember: now have .Get()
 - Cast Recorder getters to types for consistency
+- Floats can now take up to two decimal places
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -123,18 +123,18 @@ The following strip commands are available:
 - A1-A5: bool
 - B1-B3: bool
 - limit: int, from -40 to 12
-- gain: float, from -60.0 to 12.0
+- gain: float, from -60.00 to 12.00
 - label: string
-- reverb: float, from 0.0 to 10.0
-- delay: float, from 0.0 to 10.0
-- fx1: float, from 0.0 to 10.0
-- fx2: float, from 0.0 to 10.0
-- pan_x: float, from -0.5 to 0.5
-- pan_y: float, from 0.0 to 1.0
-- color_x: float, from -0.5 to 0.5
-- color_y: float, from 0.0 to 1.0
-- fx_x: float, from -0.5 to 0.5
-- fx_y: float, from 0.0 to 1.0
+- reverb: float, from 0.00 to 10.00
+- delay: float, from 0.00 to 10.00
+- fx1: float, from 0.00 to 10.00
+- fx2: float, from 0.00 to 10.00
+- pan_x: float, from -0.50 to 0.50
+- pan_y: float, from 0.00 to 1.00
+- color_x: float, from -0.50 to 0.50
+- color_y: float, from 0.00 to 1.00
+- fx_x: float, from -0.50 to 0.50
+- fx_y: float, from 0.00 to 1.00
 - postreverb: bool
 - postdelay: bool
 - postfx1: bool
@@ -157,14 +157,14 @@ mc, k for virtual strips only.
 
 The following strip.comp commands are available:
 
-- knob: float, from 0.0 to 10.0
-- gainin: float, from -24.0 to 24.0
-- ratio: float, from 1.0 to 8.0
-- threshold: float, from -40.0 to -3.0
-- attack: float, from 0.0 to 200.0
-- release: float, from 0.0 to 5000.0
-- knee: float, 0.0 to 1.0
-- gainout: float, from -24.0 to 24.0
+- knob: float, from 0.00 to 10.00
+- gainin: float, from -24.00 to 24.00
+- ratio: float, from 1.00 to 8.00
+- threshold: float, from -40.00 to -3.00
+- attack: float, from 0.00 to 200.00
+- release: float, from 0.00 to 5000.00
+- knee: float, 0.00 to 1.00
+- gainout: float, from -24.00 to 24.00
 - makeup: bool
 
 for example:
@@ -177,13 +177,13 @@ $vmr.strip[3].comp.attack = 8.5
 
 The following strip.gate commands are available:
 
-- knob: float, from 0.0 to 10.0
-- threshold: float, from -60.0 to -10.0
-- damping: float, from -60.0 to -10.0
+- knob: float, from 0.00 to 10.00
+- threshold: float, from -60.00 to -10.00
+- damping: float, from -60.00 to -10.00
 - bpsidechain: int, from 100 to 4000
-- attack: float, from 0.0 to 1000.0
-- hold: float, from 0.0 to 5000.0
-- release: float, from 0.0 to 5000.0
+- attack: float, from 0.00 to 1000.00
+- hold: float, from 0.00 to 5000.00
+- release: float, from 0.00 to 5000.00
 
 for example:
 
@@ -195,7 +195,7 @@ $vmr.strip[3].gate.threshold = -40.5
 
 The following strip.denoiser commands are available:
 
-- knob: float, from 0.0 to 10.0
+- knob: float, from 0.00 to 10.00
 
 for example:
 
@@ -238,12 +238,12 @@ The following bus commands are available:
 - monitor: bool
 - vaio: bool
 - mono: int, 0 off, 1 mono, 2 stereo reverse
-- gain: float, from -60.0 to 12.0
+- gain: float, from -60.00 to 12.00
 - label: string
-- returnreverb: float, from 0.0 to 10.0
-- returndelay: float, from 0.0 to 10.0
-- returnfx1: float, from 0.0 to 10.0
-- returnfx2: float, from 0.0 to 10.0
+- returnreverb: float, from 0.00 to 10.00
+- returndelay: float, from 0.00 to 10.00
+- returnfx1: float, from 0.00 to 10.00
+- returnfx2: float, from 0.00 to 10.00
 
 for example:
 
@@ -342,9 +342,9 @@ The following eq.channel.cell commands are available:
 
 - on: bool
 - type: int, from 0 to 6
-- f: float, from 20.0 to 20000.0
-- gain: float, from -12.0 to 12.0
-- q: float, from 0.3 to 100.0
+- f: float, from 20.00 to 20000.00
+- gain: float, from -12.00 to 12.00
+- q: float, from 0.30 to 100.00
 
 for example:
 
@@ -538,7 +538,7 @@ The following commands are available:
 
 - A1 - A5: bool
 - B1 - B3: bool
-- gain: float, from -60.0 to 12.0
+- gain: float, from -60.00 to 12.00
 - armedbus: int, from 0 to bus index
 - state: string, ('play', 'stop', 'record', 'pause')
 - prerectime: int, from 0 to 20 seconds

--- a/lib/arraymember.ps1
+++ b/lib/arraymember.ps1
@@ -43,9 +43,15 @@ class FloatArrayMember : ArrayMember {
     [int]$decimals
     
     FloatArrayMember (
-        [int]$index, [string]$prefix, [Object]$parent, [int]$decimals = 1
+        [int]$index, [string]$prefix, [Object]$parent, [int]$decimals
     ) : base ($index, $prefix, $parent) {
         $this.decimals = $decimals
+    }
+
+    FloatArrayMember (
+        [int]$index, [string]$prefix, [Object]$parent
+    ) : base ($index, $prefix, $parent) {
+        $this.decimals = 2
     }
     
     [double] Get () {

--- a/lib/meta.ps1
+++ b/lib/meta.ps1
@@ -16,12 +16,13 @@ function AddBoolMembers () {
 
 function AddFloatMembers () {
     param(
-        [String[]]$PARAMS
+        [String[]]$PARAMS,
+        [int]$decimals = 2
     )
     [hashtable]$Signatures = @{}
     foreach ($param in $PARAMS) {
         # Define getter
-        $Signatures['Getter'] = "[math]::Round(`$this.Getter('{0}'), 1)" -f $param
+        $Signatures['Getter'] = "[math]::Round(`$this.Getter('{0}'), {1})" -f $param, $decimals
         # Define setter
         $Signatures['Setter'] = "param ( [Single]`$arg )`n`$this.Setter('{0}', `$arg)" `
             -f $param

--- a/lib/option.ps1
+++ b/lib/option.ps1
@@ -14,7 +14,7 @@ class Option : IRemote {
         
         $this.delay = @()
         for ($i = 0; $i -lt $num_A; $i++) {
-            $this.delay.Add([FloatArrayMember]::new($i, 'delay', $this, 2))
+            $this.delay.Add([FloatArrayMember]::new($i, 'delay', $this))
         }
     }
     

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -885,7 +885,7 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                     $vmr.recorder.filetype = $filetype
 
                     $vmr.recorder.state = 'record'
-                    Start-Sleep -Milliseconds 100
+                    Start-Sleep -Milliseconds 10
                     $stamp = '{0:yyyy-MM-dd} at {0:HH}h{0:mm}m{0:ss}s' -f (Get-Date)
                     $vmr.recorder.state | Should -Be 'record'
                     Start-Sleep -Milliseconds 2000
@@ -979,7 +979,7 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
 
                 BeforeEach {
                     $vmr.recorder.record()
-                    Start-Sleep -Milliseconds 100
+                    Start-Sleep -Milliseconds 10
                     $stamp = '{0:yyyy-MM-dd} at {0:HH}h{0:mm}m{0:ss}s' -f (Get-Date)
                     Start-Sleep -Milliseconds 2000
 

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -244,94 +244,81 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
         }
     }
 
-    Describe 'Float Tests' -Tag 'float' {
+    Describe 'Float Tests' -Tag 'float' -ForEach @(
+        @{ Gain = -24.63; Knob = 5.27; Slide = -7.51; Xy10 = 0.83; Xy05 = -0.42; MsHz = 196.57 }
+        @{ Gain = -12.48; Knob = 8.91; Slide = 3.14; Xy10 = 0.27; Xy05 = 0.69; MsHz = 142.13 }
+    ) {
         Context 'Strip, one physical one virtual' -ForEach @(
             @{ Index = $phys_in }, @{ Index = $virt_in }
         ) {
-            It "Should set Strip[$index].Gain to $value" -ForEach @(
-                @{ Value = 3.6; Expected = 3.6 }, @{ Value = -8.2; Expected = -8.2 }
-            ) {
-                $vmr.strip[$index].gain = $value
-                $vmr.strip[$index].gain | Should -Be $expected
+            It "Should set Strip[$index].Gain" {
+                $vmr.strip[$index].gain = $gain
+                $vmr.strip[$index].gain | Should -Be $gain
             }
         }
 
-        Context 'Strip, physical only' -Skip:$ifBasic -ForEach @(
+        Context 'Strip, physical only' -ForEach @(
             @{ Index = $phys_in }
         ) {
-            Context 'Knobs' -Skip:$ifBasic -ForEach @(
-                @{ Value = 8.3; Expected = 8.3 }, @{ Value = 5.1; Expected = 5.1 }
-            ) {
-                It "Should set Strip[$index].Comp to $value" {
-                    $vmr.strip[$index].comp.knob = $value
-                    $vmr.strip[$index].comp.knob | Should -Be $expected
+            Context 'Comp, Gate' -Skip:$ifBasic {
+                It "Should set Strip[$index].Comp" {
+                    $vmr.strip[$index].comp.knob = $knob
+                    $vmr.strip[$index].comp.knob | Should -Be $knob
                 }
 
-                It "Should set Strip[$index].Gate to $value" {
-                    $vmr.strip[$index].gate.knob = $value
-                    $vmr.strip[$index].gate.knob | Should -Be $expected
-                }
-
-                It "Should set Strip[$index].Denoiser to $value" -Skip:$ifNotPotato {
-                    $vmr.strip[$index].denoiser.knob = $value
-                    $vmr.strip[$index].denoiser.knob | Should -Be $expected
+                It "Should set Strip[$index].Gate" {
+                    $vmr.strip[$index].gate.knob = $knob
+                    $vmr.strip[$index].gate.knob | Should -Be $knob
                 }
             }
 
             Context 'Comp' -Skip:$ifNotPotato {
-                It "Should set Strip[$index].Comp.Attack" -ForEach @(
-                    @{ Value = 8.3; Expected = 8.3 }, @{ Value = 5.1; Expected = 5.1 }
-                ) {
-                    $vmr.strip[$index].comp.attack = $value
-                    $vmr.strip[$index].comp.attack | Should -Be $expected
+                It "Should set Strip[$index].Comp.Attack" {
+                    $vmr.strip[$index].comp.attack = $msHz
+                    $vmr.strip[$index].comp.attack | Should -Be $msHz
                 }
 
-                It "Should set Strip[$index].Comp.Knee" -ForEach @(
-                    @{ Value = 0.3; Expected = 0.3 }, @{ Value = 0.8; Expected = 0.8 }
-                ) {
-                    $vmr.strip[$index].comp.knee = $value
-                    $vmr.strip[$index].comp.knee | Should -Be $expected
+                It "Should set Strip[$index].Comp.Knee" {
+                    $vmr.strip[$index].comp.knee = $xy10
+                    $vmr.strip[$index].comp.knee | Should -Be $xy10
                 }
             }
 
             Context 'Gate' -Skip:$ifNotPotato {
-                It "Should set Strip[$index].Gate.BPSidechain" -ForEach @(
-                    @{ Value = 103.1; Expected = 103.1 }, @{ Value = 3800; Expected = 3800 }
-                ) {
-                    $vmr.strip[$index].gate.bpsidechain = $value
-                    $vmr.strip[$index].gate.bpsidechain | Should -Be $expected
+                It "Should set Strip[$index].Gate.BPSidechain" {
+                    $vmr.strip[$index].gate.bpsidechain = $msHz
+                    $vmr.strip[$index].gate.bpsidechain | Should -Be $msHz
                 }
 
-                It "Should set Strip[$index].Gate.Hold" -ForEach @(
-                    @{ Value = 0.3; Expected = 0.3 }, @{ Value = 5000; Expected = 5000 }
-                ) {
-                    $vmr.strip[$index].gate.hold = $value
-                    $vmr.strip[$index].gate.hold | Should -Be $expected
+                It "Should set Strip[$index].Gate.Hold" {
+                    $vmr.strip[$index].gate.hold = $msHz
+                    $vmr.strip[$index].gate.hold | Should -Be $msHz
+                }
+            }
+
+            Context 'Denoiser' -Skip:$ifNotPotato {
+                It "Should set Strip[$index].Denoiser" {
+                    $vmr.strip[$index].denoiser.knob = $knob
+                    $vmr.strip[$index].denoiser.knob | Should -Be $knob
                 }
             }
 
             Context 'EQ' -Skip:$ifNotPotato -ForEach @(
                 @{ Eq = $vmr.strip[$index].eq }
             ) {
-                It "Should set Strip[$index].EQ.Channel[$strip_ch].Cell[$cells].F" -ForEach @(
-                    @{ Value = 1234.6; Expected = 1234.6 }, @{ Value = 7500; Expected = 7500 }
-                ) {
-                    $eq.channel[$strip_ch].cell[$cells].f = $value
-                    $eq.channel[$strip_ch].cell[$cells].f | Should -Be $expected
+                It "Should set Strip[$index].EQ.Channel[$strip_ch].Cell[$cells].F" {
+                    $eq.channel[$strip_ch].cell[$cells].f = $msHz
+                    $eq.channel[$strip_ch].cell[$cells].f | Should -Be $msHz
                 }
 
-                It "Should set Strip[$index].EQ.Channel[$strip_ch].Cell[$cells].Gain" -ForEach @(
-                    @{ Value = 4.2; Expected = 4.2 }, @{ Value = -7.3; Expected = -7.3 }
-                ) {
-                    $eq.channel[$strip_ch].cell[$cells].gain = $value
-                    $eq.channel[$strip_ch].cell[$cells].gain | Should -Be $expected
+                It "Should set Strip[$index].EQ.Channel[$strip_ch].Cell[$cells].Gain" {
+                    $eq.channel[$strip_ch].cell[$cells].gain = $slide
+                    $eq.channel[$strip_ch].cell[$cells].gain | Should -Be $slide
                 }
 
-                It "Should set Strip[$index].EQ.Channel[$strip_ch].Cell[$cells].Q" -ForEach @(
-                    @{ Value = 1.2; Expected = 1.2 }, @{ Value = 5.6; Expected = 5.6 }
-                ) {
-                    $eq.channel[$strip_ch].cell[$cells].q = $value
-                    $eq.channel[$strip_ch].cell[$cells].q | Should -Be $expected
+                It "Should set Strip[$index].EQ.Channel[$strip_ch].Cell[$cells].Q" {
+                    $eq.channel[$strip_ch].cell[$cells].q = $knob
+                    $eq.channel[$strip_ch].cell[$cells].q | Should -Be $knob
                 }
             }
         }
@@ -339,47 +326,37 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
         Context 'Bus, one physical one virtual' -ForEach @(
             @{ Index = $phys_out }, @{ Index = $virt_out }
         ) {
-            It "Should set Bus[$index].Gain" -ForEach @(
-                @{ Value = 5.2; Expected = 5.2 }, @{ Value = -38.2; Expected = -38.2 }
-            ) {
-                $vmr.bus[$index].gain = $value
-                $vmr.bus[$index].gain | Should -Be $expected
+            It "Should set Bus[$index].Gain" {
+                $vmr.bus[$index].gain = $gain
+                $vmr.bus[$index].gain | Should -Be $gain
             }
 
             Context 'EQ' -Skip:$ifBasic -ForEach @(
                 @{ Eq = $vmr.bus[$index].eq }
             ) {
-                It "Should set Bus[$index].EQ.Channel[$bus_ch].Cell[$cells].F" -ForEach @(
-                    @{ Value = 1234.6; Expected = 1234.6 }, @{ Value = 7500; Expected = 7500 }
-                ) {
-                    $eq.channel[$bus_ch].cell[$cells].f = $value
-                    $eq.channel[$bus_ch].cell[$cells].f | Should -Be $expected
+                It "Should set Bus[$index].EQ.Channel[$bus_ch].Cell[$cells].F" {
+                    $eq.channel[$bus_ch].cell[$cells].f = $msHz
+                    $eq.channel[$bus_ch].cell[$cells].f | Should -Be $msHz
                 }
 
-                It "Should set Bus[$index].EQ.Channel[$bus_ch].Cell[$cells].Gain" -ForEach @(
-                    @{ Value = 4.2; Expected = 4.2 }, @{ Value = -7.3; Expected = -7.3 }
-                ) {
-                    $eq.channel[$bus_ch].cell[$cells].gain = $value
-                    $eq.channel[$bus_ch].cell[$cells].gain | Should -Be $expected
+                It "Should set Bus[$index].EQ.Channel[$bus_ch].Cell[$cells].Gain" {
+                    $eq.channel[$bus_ch].cell[$cells].gain = $slide
+                    $eq.channel[$bus_ch].cell[$cells].gain | Should -Be $slide
                 }
 
-                It "Should set Bus[$index].EQ.Channel[$bus_ch].Cell[$cells].Q" -ForEach @(
-                    @{ Value = 1.2; Expected = 1.2 }, @{ Value = 5.6; Expected = 5.6 }
-                ) {
-                    $eq.channel[$bus_ch].cell[$cells].q = $value
-                    $eq.channel[$bus_ch].cell[$cells].q | Should -Be $expected
+                It "Should set Bus[$index].EQ.Channel[$bus_ch].Cell[$cells].Q" {
+                    $eq.channel[$bus_ch].cell[$cells].q = $knob
+                    $eq.channel[$bus_ch].cell[$cells].q | Should -Be $knob
                 }
             }
         }
         
         Context 'Option' {
-            It "Should set and get Option.delay[$phys_out]" -ForEach @(
-                @{ Value = 486.57 }, @{ Value = 26.41 }
-            ) {
-                $vmr.option.delay[$phys_out].set($value)
+            It "Should set and get Option.delay[$phys_out]" {
+                $vmr.option.delay[$phys_out].set($msHz)
                 $vmr.command.restart()
                 Start-Sleep -Milliseconds 2000
-                $vmr.option.delay[$phys_out].get() | Should -Be $value
+                $vmr.option.delay[$phys_out].get() | Should -Be $msHz
             }
         }
     }

--- a/tests/run.ps1
+++ b/tests/run.ps1
@@ -12,7 +12,7 @@ function Test-RecDir ([object]$vmr, [string]$recDir) {
     
     try {
         $vmr.recorder.record()
-        Start-Sleep -Milliseconds 100
+        Start-Sleep -Milliseconds 10
         $stamp = '{0:yyyy-MM-dd} at {0:HH}h{0:mm}m{0:ss}s' -f (Get-Date)
         Start-Sleep -Milliseconds 2000
 


### PR DESCRIPTION
## What

- Allows float decimal places to be set with `-decimals` param for `AddFloatMembers`.
- Corrects this behavior in `FloatArrayMember`.
- Floats now allow up to two decimal places by default.

## Why

The tooltip at the top of the GUI displays values rounded to two decimal places. Floats don't appear to be rounded internally by Voicemeeter, but only as many as two decimal places are displayed anywhere in the GUI.

This change provides flexibility for the module and a higher level of precision to the user without breaking anything. This is especially helpful for properties like `pan` and `color`, which have very small `-0.5 to 0.5` or `0.0 to 1.0` ranges.

## Testing/Notes

Pester tests pass for all kinds. Added hashtables of reusable values to `Float Tests` for ease of use because many ranges are the same/similar.

If any properties are discovered that truly only take one decimal place, those can be added with
`AddFloatMembers -decimals 1 -PARAMS @(...)`
Likewise, a higher level of precision can be provided to the user if so desired.