### PR TITLE
Strip commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Recorder.FileType changed from method to write-only property
 - Command.Save($filepath)
 - Command.StorePreset()
 - Command.RecallPreset()
+- AddAliasMembers meta function takes a hashtable `-MAP` of `alias = property`
+- Strip.Karaoke alias for Strip.K
 
 ### Changed
 
@@ -58,6 +60,7 @@ Recorder.FileType changed from method to write-only property
 - Recorder.Armstrip|Armbus -> BoolArrayMember: now have .Get()
 - Cast Recorder getters to types for consistency
 - Floats getters/setters now default to two decimal places.
+- Strip.Mono is now an alias for Strip.MC on virtual strips
 
 ### Fixed
 
@@ -69,6 +72,7 @@ Recorder.FileType changed from method to write-only property
 - vban route range (API documentation is incorrect)
 - vban.stream.sr: $this._port -> $this._sr
 - Recorder.channel values: 1..8 -> (2, 4, 6, 8)
+- Strip.Limit type [int] -> [float]
 
 ## [3.3.0] - 2024-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ Recorder.FileType changed from method to write-only property
 - AddAliasMembers meta function takes a hashtable `-MAP` of `alias = property`
 - Strip.Karaoke alias for Strip.K
 - Strip.EQGain1|EQGain2|EQGain3 with bass/low, mid/med, treble/high aliases, respectively
+- StripAudibility class with Strip.Audibility.Knob
+- Strip.Denoiser.Threshold
+- Strip.VAIO
 
 ### Changed
 
@@ -63,6 +66,7 @@ Recorder.FileType changed from method to write-only property
 - Floats getters/setters now default to two decimal places.
 - Strip.Mono is now an alias for Strip.MC on virtual strips
 - Strip.AppMute|AppGain can now take an app index; see README for details
+- Strip Knob setters: explicit $arg types for consistency
 
 ### Fixed
 
@@ -76,6 +80,7 @@ Recorder.FileType changed from method to write-only property
 - Recorder.channel values: 1..8 -> (2, 4, 6, 8)
 - Strip.Limit type [int] -> [float]
 - Missing closing parenthesis in AppMute value string
+- Strip Knob getters: `this.Getter_String('') -> [math]::Round($this.Getter(''), 2)`
 
 ## [3.3.0] - 2024-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Strip Gainlayers are now FloatArrayMember objects, see README for details
 - Strip.Mono is now an alias for Strip.MC on virtual strips
 - Strip.AppMute|AppGain can now take an app index; see README for details
 - Strip Knob setters: explicit $arg types for consistency
+- Strip.Levels.Convert hidden and return type [float] -> [single] for naming consistency
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ Recorder.FileType changed from method to write-only property
 - StripAudibility class with Strip.Audibility.Knob
 - Strip.Denoiser.Threshold
 - Strip.VAIO
+- Strip.Pitch, StripPitch class
+  - on
+  - drywet
+  - pitchvalue
+  - loformant
+  - medformant
+  - hiformant
+  - recallpreset($presetIndex)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Recorder.FileType changed from method to write-only property
 - Cast Recorder getters to types for consistency
 - Floats getters/setters now default to two decimal places.
 - Strip.Mono is now an alias for Strip.MC on virtual strips
+- Strip.AppMute|AppGain can now take an app index; see README for details
 
 ### Fixed
 
@@ -73,6 +74,7 @@ Recorder.FileType changed from method to write-only property
 - vban.stream.sr: $this._port -> $this._sr
 - Recorder.channel values: 1..8 -> (2, 4, 6, 8)
 - Strip.Limit type [int] -> [float]
+- Missing closing parenthesis in AppMute value string
 
 ## [3.3.0] - 2024-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Recorder.FileType changed from method to write-only property
 - Command.RecallPreset()
 - AddAliasMembers meta function takes a hashtable `-MAP` of `alias = property`
 - Strip.Karaoke alias for Strip.K
+- Strip.EQGain1|EQGain2|EQGain3 with bass/low, mid/med, treble/high aliases, respectively
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ AddActionMembers now adds ScriptMethods instead of ScriptProperties:
 Deprecated Recorder.Loop removed: use Recorder.Mode.Loop
 Recorder.FileType changed from method to write-only property
 
+Strip Gainlayers are now FloatArrayMember objects, see README for details
+
 ### Added
 
 - IRemote base class

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The following strip commands are available:
 - fx1: float, from 0.00 to 10.00
 - fx2: float, from 0.00 to 10.00
 - pan_x: float, from -0.50 to 0.50
-- pan_y: float, from 0.00 to 1.00
+- pan_y: float, physical: from 0.00 to 1.00, virtual: from -0.50 to 0.50
 - color_x: float, from -0.50 to 0.50
 - color_y: float, from 0.00 to 1.00
 - fx_x: float, from -0.50 to 0.50
@@ -147,6 +147,11 @@ The following strip commands are available:
 for example:
 
 ```powershell
+$vmr.strip[6].karaoke = 3
+$vmr.strip[0].limit = 4.5
+$vmr.strip[2].label = 'example'
+$vmr.stirp[7].pan_y = -0.38
+$vmr.strip[5].treble = -2.43
 ```
 
 A,B commands depend on Voicemeeter type.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ The following strip commands are available:
 - postdelay: bool
 - postfx1: bool
 - postfx2: bool
-- gainlayer0-gainlayer7: float
 - eqgain1/bass/low: float, from -12.00 to 12.00
 - eqgain2/mid/med: float, from -12.00 to 12.00
 - eqgain3/treble/high: float, from -12.00 to 12.00
@@ -148,7 +147,6 @@ The following strip commands are available:
 for example:
 
 ```powershell
-$vmr.strip[5].gainlayer1 = -8.3
 ```
 
 A,B commands depend on Voicemeeter type.
@@ -233,6 +231,19 @@ for example:
 
 ```powershell
 $vmr.strip[1].audibility.knob = 2.66
+```
+
+#### Gainlayer[i]
+
+The following strip.gainlayer[i] methods are available:
+
+- Set($val) : float, from -60.00 to 12.00
+- Get()
+
+for example:
+
+```powershell
+$vmr.strip[4].gainlayer[7].set(-26.81)
 ```
 
 #### AppGain | AppMute

--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ The following strip commands are available:
 - mute: bool
 - mono: bool
 - mc: bool
-- k: int, from 0 to 4
+- k/karaoke: int, from 0 to 4
 - solo: bool
 - A1-A5: bool
 - B1-B3: bool
-- limit: int, from -40 to 12
+- limit: float, from -40.00 to 12.00
 - gain: float, from -60.00 to 12.00
 - label: string
 - reverb: float, from 0.00 to 10.00

--- a/README.md
+++ b/README.md
@@ -150,13 +150,11 @@ for example:
 $vmr.strip[6].karaoke = 3
 $vmr.strip[0].limit = 4.5
 $vmr.strip[2].label = 'example'
-$vmr.stirp[7].pan_y = -0.38
+$vmr.strip[7].pan_y = -0.38
 $vmr.strip[5].treble = -2.43
 ```
 
 A,B commands depend on Voicemeeter type.
-
-gainlayers defined for Potato version only.
 
 mc, k for virtual strips only.
 

--- a/README.md
+++ b/README.md
@@ -205,14 +205,16 @@ $vmr.strip[3].denoiser.knob = 5
 
 #### AppGain | AppMute
 
-- `AppGain(amount, gain)` : string, float
-- `AppMute(amount, mutestate)` : string, bool
+- AppGain($appname or $appindex, $gain) : string or int, float, from 0.00 to 1.00
+- AppMute($appname or $appindex, $mutestate) : string or int, bool
 
 for example:
 
 ```powershell
 $vmr.strip[5].AppGain("Spotify", 0.5)
 $vmr.strip[5].AppMute("Spotify", $true)
+$vmr.strip[7].AppGain(0, 0.28)
+$vmr.strip[6].AppMute(2, $false)
 ```
 
 #### levels

--- a/README.md
+++ b/README.md
@@ -224,6 +224,14 @@ The following strip.pitch methods are available:
 
 - RecallPreset($presetIndex) : int, from 0 to 7
 
+for example:
+
+```powershell
+$vmr.strip[2].pitch.recallpreset(4)
+$vmr.strip[4].pitch.drywet = -22.86
+$vmr.strip[1].pitch.medformant = 2.1
+```
+
 #### audibility
 
 The following strip.audibility commands are available:

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ The following strip commands are available:
 - postfx1: bool
 - postfx2: bool
 - gainlayer0-gainlayer7: float
+- eqgain1/bass/low: float, from -12.00 to 12.00
+- eqgain2/mid/med: float, from -12.00 to 12.00
+- eqgain3/treble/high: float, from -12.00 to 12.00
 
 for example:
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,21 @@ for example:
 $vmr.strip[3].denoiser.knob = 5
 ```
 
+#### pitch
+
+The following strip.pitch commands are available:
+
+- on: bool
+- drywet: float, from -100.00 to 100.00
+- pitchvalue: float, from -12.00 to 12.00
+- loformant: float, from -12.00 to 12.00
+- medformant: float, from -12.00 to 12.00
+- hiformant: float, from -12.00 to 12.00
+
+The following strip.pitch methods are available:
+
+- RecallPreset($presetIndex) : int, from 0 to 7
+
 #### audibility
 
 The following strip.audibility commands are available:

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The following strip commands are available:
 - solo: bool
 - A1-A5: bool
 - B1-B3: bool
+- vaio: bool
 - limit: float, from -40.00 to 12.00
 - gain: float, from -60.00 to 12.00
 - label: string
@@ -199,11 +200,24 @@ $vmr.strip[3].gate.threshold = -40.5
 The following strip.denoiser commands are available:
 
 - knob: float, from 0.00 to 10.00
+- threshold: float, from 0.00 to 10.00
 
 for example:
 
 ```powershell
 $vmr.strip[3].denoiser.knob = 5
+```
+
+#### audibility
+
+The following strip.audibility commands are available:
+
+- knob: float, from 0.00 to 10.00
+
+for example:
+
+```powershell
+$vmr.strip[1].audibility.knob = 2.66
 ```
 
 #### AppGain | AppMute

--- a/lib/kinds.ps1
+++ b/lib/kinds.ps1
@@ -12,6 +12,7 @@ $KindMap = @{
         'vban'      = @{ 'in' = 4; 'out' = 4; 'midi' = 1; 'text' = 1 }
         'eq_ch'     = @{ 'strip' = 0; 'bus' = 0 }
         'cells'     = 0
+        'gainlayer' = 0
     };
     'banana' = @{
         'name'      = 'banana'
@@ -26,6 +27,7 @@ $KindMap = @{
         'vban'      = @{ 'in' = 8; 'out' = 8; 'midi' = 1; 'text' = 1 }
         'eq_ch'     = @{ 'strip' = 0; 'bus' = 8 }
         'cells'     = 6
+        'gainlayer' = 0
     };
     'potato' = @{
         'name'      = 'potato'
@@ -40,6 +42,7 @@ $KindMap = @{
         'vban'      = @{ 'in' = 8; 'out' = 8; 'midi' = 1; 'text' = 1 }
         'eq_ch'     = @{ 'strip' = 2; 'bus' = 8 }
         'cells'     = 6
+        'gainlayer' = 8
     };
 }
 

--- a/lib/meta.ps1
+++ b/lib/meta.ps1
@@ -74,6 +74,16 @@ function AddActionMembers () {
     }
 }
 
+function AddAliasMembers () {
+    param(
+        [hashtable]$MAP
+    )
+    foreach ($alias in $MAP.Keys) {
+        $this | Add-Member -MemberType AliasProperty -Name $alias `
+            -Value $MAP[$alias] -Force
+    }
+}
+
 function AddChannelMembers () {
     $num_A = $this.remote.kind.p_out
     $num_B = $this.remote.kind.v_out

--- a/lib/meta.ps1
+++ b/lib/meta.ps1
@@ -96,21 +96,6 @@ function AddChannelMembers () {
     AddBoolMembers -PARAMS $channels
 }
 
-function AddGainlayerMembers () {
-    [hashtable]$Signatures = @{}
-    0..7 | ForEach-Object {
-        # Define getter
-        $Signatures['Getter'] = "`$this.Getter('gainlayer[{0}]')" -f $_
-        # Define setter
-        $Signatures['Setter'] = "param ( [Single]`$arg )`n`$this.Setter('gainlayer[{0}]', `$arg)" `
-            -f $_
-        $param = 'gainlayer{0}' -f $_
-        $null = $param
-
-        Addmember
-    }
-}
-
 function Addmember {
     $AddMemberParams = @{
         Name        = $param

--- a/lib/strip.ps1
+++ b/lib/strip.ps1
@@ -46,7 +46,7 @@ class StripLevels : IRemote {
         }
     }
 
-    [float] Convert([float]$val) {
+    hidden [single] Convert([single]$val) {
         if ($val -gt 0) { 
             return [math]::Round(20 * [math]::Log10($val), 1) 
         } 

--- a/lib/strip.ps1
+++ b/lib/strip.ps1
@@ -78,6 +78,7 @@ class PhysicalStrip : Strip {
     [Object]$eq
     [Object]$device
     [Object]$audibility
+    [Object]$pitch
 
     PhysicalStrip ([int]$index, [Object]$remote) : base ($index, $remote) {
         AddFloatMembers -PARAMS @('color_x', 'color_y', 'fx_x', 'fx_y')
@@ -88,6 +89,7 @@ class PhysicalStrip : Strip {
         $this.comp = [StripComp]::new($index, $remote)
         $this.gate = [StripGate]::new($index, $remote)
         $this.denoiser = [StripDenoiser]::new($index, $remote)
+        $this.pitch = [StripPitch]::new($index, $remote)
         $this.audibility = [StripAudibility]::new($index, $remote)
         $this.eq = [StripEq]::new($index, $remote)
         $this.device = [StripDevice]::new($index, $remote)
@@ -153,6 +155,21 @@ class StripDenoiser : IRemote {
             return $this.Setter('', $arg)
         }
     )
+}
+
+class StripPitch : IRemote {
+    StripPitch ([int]$index, [Object]$remote) : base ($index, $remote) {
+        AddBoolMembers -PARAMS @('on')
+        AddFloatMembers -PARAMS @('drywet', 'pitchvalue', 'loformant', 'medformant', 'hiformant')
+    }
+
+    [string] identifier () {
+        return 'Strip[' + $this.index + '].Pitch'
+    }
+
+    [void] RecallPreset ([int]$presetIndex) {
+        $this.Setter('RecallPreset', $presetIndex)
+    }
 }
 
 class StripAudibility : IRemote {

--- a/lib/strip.ps1
+++ b/lib/strip.ps1
@@ -2,9 +2,8 @@ class Strip : IRemote {
     [Object]$levels
 
     Strip ([int]$index, [Object]$remote) : base ($index, $remote) {
-        AddBoolMembers -PARAMS @('mono', 'solo', 'mute')
-        AddIntMembers -PARAMS @('limit')
-        AddFloatMembers -PARAMS @('gain', 'pan_x', 'pan_y')
+        AddBoolMembers -PARAMS @('solo', 'mute')
+        AddFloatMembers -PARAMS @('gain', 'limit', 'pan_x', 'pan_y')
         AddStringMembers -PARAMS @('label')
 
         AddChannelMembers
@@ -83,6 +82,7 @@ class PhysicalStrip : Strip {
         AddFloatMembers -PARAMS @('color_x', 'color_y', 'fx_x', 'fx_y')
         AddFloatMembers -PARAMS @('reverb', 'delay', 'fx1', 'fx2')
         AddBoolMembers -PARAMS @('postreverb', 'postdelay', 'postfx1', 'postfx2')
+        AddBoolMembers -PARAMS @('mono')
 
         $this.comp = [StripComp]::new($index, $remote)
         $this.gate = [StripGate]::new($index, $remote)
@@ -174,6 +174,8 @@ class VirtualStrip : Strip {
     VirtualStrip ([int]$index, [Object]$remote) : base ($index, $remote) {
         AddBoolMembers -PARAMS @('mc')
         AddIntMembers -PARAMS @('k')
+
+        AddAliasMembers -MAP @{ mono = 'mc'; karaoke = 'k' }
     }
 
     [void] AppGain ([string]$appname, [single]$gain) {

--- a/lib/strip.ps1
+++ b/lib/strip.ps1
@@ -1,4 +1,5 @@
 class Strip : IRemote {
+    [System.Collections.ArrayList]$gainlayer
     [Object]$levels
 
     Strip ([int]$index, [Object]$remote) : base ($index, $remote) {
@@ -7,9 +8,13 @@ class Strip : IRemote {
         AddStringMembers -PARAMS @('label')
 
         AddChannelMembers
-        AddGainlayerMembers
 
         $this.levels = [StripLevels]::new($index, $remote)
+
+        $this.gainlayer = @()
+        for ($i = 0; $i -lt $remote.kind.gainlayer; $i++) {
+            $this.gainlayer.Add([FloatArrayMember]::new($i, 'gainlayer', $this))
+        }
     }
 
     [string] identifier () {

--- a/lib/strip.ps1
+++ b/lib/strip.ps1
@@ -182,8 +182,16 @@ class VirtualStrip : Strip {
         $this.Setter('AppGain', "(`"$appname`", $gain)")
     }
 
+    [void] AppGain ([int]$appindex, [single]$gain) {
+        $this.Setter("App[$appindex].Gain", $gain)
+    }
+
     [void] AppMute ([string]$appname, [bool]$mutestate) {
-        $this.Setter('AppMute', "(`"$appname`", $(if ($mutestate) { 1 } else { 0 })")
+        $this.Setter('AppMute', "(`"$appname`", $(if ($mutestate) { 1 } else { 0 }))")
+    }
+
+    [void] AppMute ([int]$appindex, [bool]$mutestate) {
+        $this.Setter("App[$appindex].Mute", $mutestate)
     }
 }
 

--- a/lib/strip.ps1
+++ b/lib/strip.ps1
@@ -174,8 +174,18 @@ class VirtualStrip : Strip {
     VirtualStrip ([int]$index, [Object]$remote) : base ($index, $remote) {
         AddBoolMembers -PARAMS @('mc')
         AddIntMembers -PARAMS @('k')
+        AddFloatMembers -PARAMS @('eqgain1', 'eqgain2', 'eqgain3')
 
-        AddAliasMembers -MAP @{ mono = 'mc'; karaoke = 'k' }
+        AddAliasMembers -MAP @{ 
+            mono    = 'mc'
+            karaoke = 'k'
+            bass    = 'eqgain1'
+            low     = 'eqgain1'
+            mid     = 'eqgain2'
+            med     = 'eqgain2'
+            treble  = 'eqgain3'
+            high    = 'eqgain3'
+        }
     }
 
     [void] AppGain ([string]$appname, [single]$gain) {

--- a/lib/strip.ps1
+++ b/lib/strip.ps1
@@ -77,16 +77,18 @@ class PhysicalStrip : Strip {
     [Object]$denoiser
     [Object]$eq
     [Object]$device
+    [Object]$audibility
 
     PhysicalStrip ([int]$index, [Object]$remote) : base ($index, $remote) {
         AddFloatMembers -PARAMS @('color_x', 'color_y', 'fx_x', 'fx_y')
         AddFloatMembers -PARAMS @('reverb', 'delay', 'fx1', 'fx2')
         AddBoolMembers -PARAMS @('postreverb', 'postdelay', 'postfx1', 'postfx2')
-        AddBoolMembers -PARAMS @('mono')
+        AddBoolMembers -PARAMS @('mono', 'vaio')
 
         $this.comp = [StripComp]::new($index, $remote)
         $this.gate = [StripGate]::new($index, $remote)
         $this.denoiser = [StripDenoiser]::new($index, $remote)
+        $this.audibility = [StripAudibility]::new($index, $remote)
         $this.eq = [StripEq]::new($index, $remote)
         $this.device = [StripDevice]::new($index, $remote)
     }
@@ -104,10 +106,10 @@ class StripComp : IRemote {
 
     hidden $_knob = $($this | Add-Member ScriptProperty 'knob' `
         {
-            $this.Getter_String('')
+            [math]::Round($this.Getter(''), 2)
         } `
         {
-            param($arg)
+            param([single]$arg)
             return $this.Setter('', $arg)
         }
     )
@@ -124,10 +126,10 @@ class StripGate : IRemote {
 
     hidden $_knob = $($this | Add-Member ScriptProperty 'knob' `
         {
-            $this.Getter_String('')
+            [math]::Round($this.Getter(''), 2)
         } `
         {
-            param($arg)
+            param([single]$arg)
             return $this.Setter('', $arg)
         }
     )
@@ -135,6 +137,7 @@ class StripGate : IRemote {
 
 class StripDenoiser : IRemote {
     StripDenoiser ([int]$index, [Object]$remote) : base ($index, $remote) {
+        AddFloatMembers -PARAMS @('threshold')
     }
 
     [string] identifier () {
@@ -143,10 +146,29 @@ class StripDenoiser : IRemote {
 
     hidden $_knob = $($this | Add-Member ScriptProperty 'knob' `
         {
-            $this.Getter_String('')
+            [math]::Round($this.Getter(''), 2)
         } `
         {
-            param($arg)
+            param([single]$arg)
+            return $this.Setter('', $arg)
+        }
+    )
+}
+
+class StripAudibility : IRemote {
+    StripAudibility ([int]$index, [Object]$remote) : base ($index, $remote) {
+    }
+
+    [string] identifier () {
+        return 'Strip[' + $this.index + '].Audibility'
+    }
+
+    hidden $_knob = $($this | Add-Member ScriptProperty 'knob' `
+        {
+            [math]::Round($this.Getter(''), 2)
+        } `
+        {
+            param([single]$arg)
             return $this.Setter('', $arg)
         }
     )

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -272,7 +272,7 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
 
     Describe 'Float Tests' -Tag 'float' -ForEach @(
         @{ Gain = -24.63; Knob = 5.27; Slide = -7.51; Xy10 = 0.83; Xy05 = -0.42; MsHz = 196.57 }
-        @{ Gain = -12.48; Knob = 8.91; Slide = 3.14; Xy10 = 0.27; Xy05 = 0.69; MsHz = 142.13 }
+        @{ Gain = -12.48; Knob = 8.91; Slide = 3.14; Xy10 = 0.27; Xy05 = 0.29; MsHz = 142.13 }
     ) {
         Context 'Strip, one physical one virtual' -ForEach @(
             @{ Index = $phys_in }, @{ Index = $virt_in }
@@ -300,6 +300,11 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
         Context 'Strip, physical only' -ForEach @(
             @{ Index = $phys_in }
         ) {
+            It "Should set Strip[$index].Pan_Y" {
+                $vmr.strip[$index].pan_y = $xy10
+                $vmr.strip[$index].pan_y | Should -Be $xy10
+            }
+            
             Context 'Comp, Gate' -Skip:$ifBasic {
                 It "Should set Strip[$index].Comp" {
                     $vmr.strip[$index].comp.knob = $knob
@@ -405,6 +410,11 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
         Context 'Strip, virtual only' -ForEach @(
             @{ Index = $virt_in }
         ) {
+            It "Should set Strip[$index].Pan_Y" {
+                $vmr.strip[$index].pan_y = $xy05
+                $vmr.strip[$index].pan_y | Should -Be $xy05
+            }
+            
             Context 'EQ' {
                 BeforeEach {
                     $vmr.strip[$index].eqgain1 = 0

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -286,6 +286,15 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 $vmr.strip[$index].limit = $gain
                 $vmr.strip[$index].limit | Should -Be $gain
             }
+
+            Context 'Gainlayers' -Skip:$ifNotPotato -ForEach @(
+                @{ Layer = $phys_out }, @{ Layer = $virt_out }
+            ) {
+                It "Should set Strip[$index].Gainlayer[$layer]" {
+                    $vmr.strip[$index].gainlayer[$layer].set($gain)
+                    $vmr.strip[$index].gainlayer[$layer].get() | Should -Be $gain
+                }
+            }
         }
 
         Context 'Strip, physical only' -ForEach @(

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -34,6 +34,11 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 $vmr.strip[$index].mono = $value
                 $vmr.strip[$index].mono | Should -Be $expected
             }
+
+            It "Should set Strip[$index].VAIO" {
+                $vmr.strip[$index].vaio = $value
+                $vmr.strip[$index].vaio | Should -Be $expected
+            }
             
             Context 'Eq' -Skip:$ifNotPotato -ForEach @(
                 @{ Eq = $vmr.strip[$index].eq }
@@ -319,6 +324,18 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 It "Should set Strip[$index].Denoiser" {
                     $vmr.strip[$index].denoiser.knob = $knob
                     $vmr.strip[$index].denoiser.knob | Should -Be $knob
+                }
+
+                It "Should set Strip[$index].Denoiser.Threshold" {
+                    $vmr.strip[$index].denoiser.threshold = $knob
+                    $vmr.strip[$index].denoiser.threshold | Should -Be $knob
+                }
+            }
+
+            Context 'Audibility' -Skip:$ifNotBasic {
+                It "Should set Strip[$index].Audibility" {
+                    $vmr.strip[$index].audibility.knob = $knob
+                    $vmr.strip[$index].audibility.knob | Should -Be $knob
                 }
             }
 

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -30,6 +30,11 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
         Context 'Strip, physical only' -ForEach @(
             @{ Index = $phys_in }
         ) {
+            It "Should set Strip[$index].Mono" {
+                $vmr.strip[$index].mono = $value
+                $vmr.strip[$index].mono | Should -Be $expected
+            }
+            
             Context 'Eq' -Skip:$ifNotPotato -ForEach @(
                 @{ Eq = $vmr.strip[$index].eq }
             ) {
@@ -47,6 +52,15 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                     $eq.channel[$strip_ch].cell[$cells].on = $value
                     $eq.channel[$strip_ch].cell[$cells].on | Should -Be $value
                 }
+            }
+        }
+
+        Context 'Strip, first virtual' -ForEach @(
+            @{ Index = $phys_in + 1 }
+        ) {
+            It "Should set Strip[$index].MC via alias 'Mono'" {
+                $vmr.strip[$index].mono = $value
+                $vmr.strip[$index].mc | Should -Be $expected
             }
         }
 
@@ -255,6 +269,11 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 $vmr.strip[$index].gain = $gain
                 $vmr.strip[$index].gain | Should -Be $gain
             }
+
+            It "Should set Strip[$index].Limit" -Skip:$ifBasic {
+                $vmr.strip[$index].limit = $gain
+                $vmr.strip[$index].limit | Should -Be $gain
+            }
         }
 
         Context 'Strip, physical only' -ForEach @(
@@ -362,18 +381,6 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
     }
 
     Describe 'Int Tests' -Tag 'int' {
-        Context 'Strip, one physical, one virtual' -ForEach @(
-            @{ Index = $phys_in }, @{ Index = $virt_in }
-        ) {
-            It "Should set and get Strip[$index].Limit" -Skip:$ifBasic -ForEach @(
-                @{ Value = 3; Expected = 3 }
-                @{ Value = -6; Expected = -6 }
-            ) {
-                $vmr.strip[$index].limit = $value
-                $vmr.strip[$index].limit | Should -Be $expected
-            }
-        }
-
         Context 'Strip, physical only' -ForEach @(
             @{ Index = $phys_in }
         ) {
@@ -392,6 +399,19 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                     $eq.channel[$strip_ch].cell[$cells].type = $value
                     $eq.channel[$strip_ch].cell[$cells].type | Should -Be $expected
                 }
+            }
+        }
+
+        Context 'Strip, second virtual' -Skip:$ifBasic -ForEach @(
+            @{ Index = $phys_in + 2 }
+        ) {
+            It "Should set Strip[$index].K via alias 'Karaoke'" -ForEach @(
+                @{ Value = 0; Expected = 0 }
+                @{ Value = 2; Expected = 2 }
+                @{ Value = 4; Expected = 4 }
+            ) { 
+                $vmr.strip[$index].karaoke = $value
+                $vmr.strip[$index].k | Should -Be $expected
             }
         }
 

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -39,6 +39,13 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 $vmr.strip[$index].vaio = $value
                 $vmr.strip[$index].vaio | Should -Be $expected
             }
+
+            Context 'Pitch' -Skip:$ifNotPotato {
+                It "Should set Strip[$index].Pitch.On" {
+                    $vmr.strip[$index].pitch.on = $value
+                    $vmr.strip[$index].pitch.on | Should -Be $expected
+                }
+            }
             
             Context 'Eq' -Skip:$ifNotPotato -ForEach @(
                 @{ Eq = $vmr.strip[$index].eq }
@@ -329,6 +336,33 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
                 It "Should set Strip[$index].Denoiser.Threshold" {
                     $vmr.strip[$index].denoiser.threshold = $knob
                     $vmr.strip[$index].denoiser.threshold | Should -Be $knob
+                }
+            }
+
+            Context 'Pitch' -Skip:$ifNotPotato {
+                It "Should set Strip[$index].Pitch.drywet" {
+                    $vmr.strip[$index].pitch.drywet = $slide
+                    $vmr.strip[$index].pitch.drywet | Should -Be $slide
+                }
+
+                It "Should set Strip[$index].Pitch.pitchvalue" {
+                    $vmr.strip[$index].pitch.pitchvalue = $slide
+                    $vmr.strip[$index].pitch.pitchvalue | Should -Be $slide
+                }
+
+                It "Should set Strip[$index].Pitch.loformant" {
+                    $vmr.strip[$index].pitch.loformant = $slide
+                    $vmr.strip[$index].pitch.loformant | Should -Be $slide
+                }
+
+                It "Should set Strip[$index].Pitch.medformant" {
+                    $vmr.strip[$index].pitch.medformant = $slide
+                    $vmr.strip[$index].pitch.medformant | Should -Be $slide
+                }
+
+                It "Should set Strip[$index].Pitch.hiformant" {
+                    $vmr.strip[$index].pitch.hiformant = $slide
+                    $vmr.strip[$index].pitch.hiformant | Should -Be $slide
                 }
             }
 

--- a/tests/higher.Tests.ps1
+++ b/tests/higher.Tests.ps1
@@ -342,6 +342,48 @@ Describe -Tag 'higher', -TestName 'All Higher Tests' {
             }
         }
 
+        Context 'Strip, virtual only' -ForEach @(
+            @{ Index = $virt_in }
+        ) {
+            Context 'EQ' {
+                BeforeEach {
+                    $vmr.strip[$index].eqgain1 = 0
+                    $vmr.strip[$index].eqgain2 = 0
+                    $vmr.strip[$index].eqgain3 = 0
+                }
+            
+                It "Should set Strip[$index].EQGain1 via alias 'bass'" {
+                    $vmr.strip[$index].bass = $slide
+                    $vmr.strip[$index].eqgain1 | Should -Be $slide
+                }
+
+                It "Should set Strip[$index].EQGain1 via alias 'low'" {
+                    $vmr.strip[$index].low = $slide
+                    $vmr.strip[$index].eqgain1 | Should -Be $slide
+                }
+
+                It "Should set Strip[$index].EQGain2 via alias 'mid'" {
+                    $vmr.strip[$index].mid = $slide
+                    $vmr.strip[$index].eqgain2 | Should -Be $slide
+                }
+
+                It "Should set Strip[$index].EQGain2 via alias 'med'" {
+                    $vmr.strip[$index].med = $slide
+                    $vmr.strip[$index].eqgain2 | Should -Be $slide
+                }
+
+                It "Should set Strip[$index].EQGain3 via alias 'treble'" {
+                    $vmr.strip[$index].treble = $slide
+                    $vmr.strip[$index].eqgain3 | Should -Be $slide
+                }
+
+                It "Should set Strip[$index].EQGain3 via alias 'high'" {
+                    $vmr.strip[$index].high = $slide
+                    $vmr.strip[$index].eqgain3 | Should -Be $slide
+                }
+            }
+        }
+
         Context 'Bus, one physical one virtual' -ForEach @(
             @{ Index = $phys_out }, @{ Index = $virt_out }
         ) {


### PR DESCRIPTION
Closes #21 

## What

Makes a number of additions, changes, and fixes to Strip, including new `StripPitch` and `StripAudibility` classes and a new meta function `AddAliasMembers`.

This PR introduces a breaking change: Gainlayers are now `FloatArrayMembers`; details below

### Adds

```powershell
$vmr.strip[$i].vaio = [bool]

$vmr.strip[$i].eqgain1 = [float]
$vmr.strip[$i].eqgain2 = [float]
$vmr.strip[$i].eqgain3 = [float]
# aliases for eqgain1, eqgain2, eqgain3
$vmr.strip[$i].bass = [float]
$vmr.strip[$i].low = [float]
$vmr.strip[$i].mid = [float]
$vmr.strip[$i].med = [float]
$vmr.strip[$i].treble = [float]
$vmr.strip[$i].high = [float]

$vmr.strip[$i].karaoke = [int]   # alias for strip.k

$vmr.strip[$i].denoiser.threshold = [float]
```

- `StripAudibility` class for Voicemeeter Basic with
```powershell
$vmr.strip[$i].audibility.knob = [float]
```

- `StripPitch` class for Voicemeeter Potato with
```powershell
$vmr.strip[$i].pitch.on = [bool]
$vmr.strip[$i].pitch.drywet = [float]
$vmr.strip[$i].pitch.pitchvalue = [float]
$vmr.strip[$i].pitch.loformant = [float]
$vmr.strip[$i].pitch.medformant = [float]
$vmr.strip[$i].pitch.hiformant = [float]

$vmr.strip[$i].pitch.recallpreset([int]$presetIndex)
```

- `AddAliasMembers` meta function takes a hashtable `-MAP` of `alias = property`
```powershell
AddAliasMembers -MAP @{ aliasA = 'property1'; aliasB = 'property1'; aliasC = 'property2' }
```

### Changes

- `Strip.Mono` is now an alias for `Strip.MC` on virtual strips
- Knob setters: explicit `$arg` types for consistency
- `Strip.Levels.Convert` hidden and return type `[float] -> [single]` for naming consistency
- `Strip.AppMute` and `Strip.AppGain` now have overloads which take an app index
```powershell
$vmr.strip[$i].appmute([int]$appIndex, [bool]$mute)
$vmr.strip[$i].appgain([int]$appIndex, [float]$gain)
```
- Gainlayers are now added as `FloatArrayMember` objects with `Set($val)` and `Get()`. This is a breaking change.
```powershell
$vmr.strip[$i].gainlayer[$j].set(-36.21)
$vmr.strip[$i].gainlayer[$j].get()
```

### Fixes

- `Strip.Limit` type `[int] -> [float]`
- Missing closing parenthesis in `AppMute` value string
- Knob getters: `this.Getter_String('') -> [math]::Round($this.Getter(''), 2)`

## Testing summary

Pester tests pass for all kinds

Manual tests for potato pass
- `Strip.Pitch.RecallPreset`
- `Strip.AppMute`
- `Strip.AppGain`

## Notes

I want to make a few unrelated changes/corrections to the CHANGELOG and README in another small PR, ~~but unless I come across something else, these should be the last changes to the actual module for now.~~ I'll have more in about a week when Voicemeeter x.1.2.x releases!