### PR TITLE
Meta functions read/write only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,9 +72,11 @@ Strip Gainlayers are now FloatArrayMember objects, see README for details
 
 ### Changed
 
-- Device: explicit $arg types for consistency
+- Meta functions can now take a -ReadOnly or -WriteOnly switch parameter
 - Meta: AddBoolMembers, AddIntMembers $arg types for consistency
 - Float getters/setters now default to two decimal places.
+- Device: explicit $arg types for consistency
+- Device members now added with meta functions
 
 - some vban.instream | vban.outstream commands now added with meta functions
   - on
@@ -84,6 +86,7 @@ Strip Gainlayers are now FloatArrayMember objects, see README for details
 
 - Recorder.Armstrip|Armbus -> BoolArrayMember: now have .Get()
 - Cast Recorder getters to types for consistency
+- Recorder.Prefix now added with AddStringMembers
 
 - Strip.Mono is now an alias for Strip.MC on virtual strips
 - Strip.AppMute|AppGain can now take an app index; see README for details

--- a/lib/bus.ps1
+++ b/lib/bus.ps1
@@ -99,22 +99,12 @@ class VirtualBus : Bus {
 class BusDevice : IODevice {
     BusDevice ([int]$index, [Object]$remote) : base ($index, $remote) {
         if ($this.index -eq 0) {
-            $this.AddASIO()
+            AddStringMembers -PARAMS @('asio') -WriteOnly
         }
     }
 
     [string] identifier () {
         return 'Bus[' + $this.index + '].Device'
-    }
-
-    hidden [void] AddASIO () {
-        Add-Member -InputObject $this -MemberType ScriptProperty -Name 'asio' `
-            -Value {
-            return Write-Warning ("ERROR: $($this.identifier()).asio is write only")
-        } -SecondValue {
-            param([string]$arg)
-            return $this.Setter('asio', $arg)
-        } -Force
     }
 }
 

--- a/lib/io.ps1
+++ b/lib/io.ps1
@@ -99,53 +99,8 @@ class EqCell : IRemote {
 
 class IODevice : IRemote {
     IODevice ([int]$index, [Object]$remote) : base ($index, $remote) {
+        AddStringMembers -WriteOnly -PARAMS @('wdm', 'ks', 'mme')
+        AddStringMembers -ReadOnly -PARAMS @('name')
+        AddIntMembers -ReadOnly -PARAMS @('sr')
     }
-
-    hidden $_name = $($this | Add-Member ScriptProperty 'name' `
-        {
-            $this.Getter_String('name')
-        } `
-        {
-            return Write-Warning ("ERROR: $($this.identifier()).name is read only")
-        }
-    )
-
-    hidden $_sr = $($this | Add-Member ScriptProperty 'sr' `
-        {
-            [int]$this.Getter('sr')
-        } `
-        {
-            return Write-Warning ("ERROR: $($this.identifier()).sr is read only")
-        }
-    )
-
-    hidden $_wdm = $($this | Add-Member ScriptProperty 'wdm' `
-        {
-            return Write-Warning ("ERROR: $($this.identifier()).wdm is write only")
-        } `
-        {
-            param([string]$arg)
-            return $this.Setter('wdm', $arg)
-        }
-    )
-
-    hidden $_ks = $($this | Add-Member ScriptProperty 'ks' `
-        {
-            return Write-Warning ("ERROR: $($this.identifier()).ks is write only")
-        } `
-        {
-            param([string]$arg)
-            return $this.Setter('ks', $arg)
-        }
-    )
-
-    hidden $_mme = $($this | Add-Member ScriptProperty 'mme' `
-        {
-            return Write-Warning ("ERROR: $($this.identifier()).mme is write only")
-        } `
-        {
-            param([string]$arg)
-            return $this.Setter('mme', $arg)
-        }
-    )
 }

--- a/lib/meta.ps1
+++ b/lib/meta.ps1
@@ -1,6 +1,6 @@
 function AddBoolMembers () {
     param(
-        [String[]]$PARAMS
+        [String[]]$PARAMS, [Switch]$readOnly, [Switch]$writeOnly
     )
     [hashtable]$Signatures = @{}
     foreach ($param in $PARAMS) {
@@ -10,13 +10,13 @@ function AddBoolMembers () {
         $Signatures['Setter'] = "param ( [bool]`$arg )`n`$this.Setter('{0}', `$arg)" `
             -f $param
 
-        Addmember
+        Addmember -ReadOnly:$readOnly -WriteOnly:$writeOnly
     }
 }
 
 function AddFloatMembers () {
     param(
-        [String[]]$PARAMS,
+        [String[]]$PARAMS, [Switch]$readOnly, [Switch]$writeOnly,
         [int]$decimals = 2
     )
     [hashtable]$Signatures = @{}
@@ -27,13 +27,13 @@ function AddFloatMembers () {
         $Signatures['Setter'] = "param ( [Single]`$arg )`n`$this.Setter('{0}', `$arg)" `
             -f $param
 
-        Addmember
+        Addmember -ReadOnly:$readOnly -WriteOnly:$writeOnly
     }
 }
 
 function AddIntMembers () {
     param(
-        [String[]]$PARAMS
+        [String[]]$PARAMS, [Switch]$readOnly, [Switch]$writeOnly
     )
     [hashtable]$Signatures = @{}
     foreach ($param in $PARAMS) {
@@ -43,13 +43,13 @@ function AddIntMembers () {
         $Signatures['Setter'] = "param ( [Int]`$arg )`n`$this.Setter('{0}', `$arg)" `
             -f $param
 
-        Addmember
+        Addmember -ReadOnly:$readOnly -WriteOnly:$writeOnly
     }
 }
 
 function AddStringMembers () {
     param(
-        [String[]]$PARAMS
+        [String[]]$PARAMS, [Switch]$readOnly, [Switch]$writeOnly
     )
     [hashtable]$Signatures = @{}
     foreach ($param in $PARAMS) {
@@ -59,7 +59,7 @@ function AddStringMembers () {
         $Signatures['Setter'] = "param ( [String]`$arg )`n`$this.Setter('{0}', `$arg)" `
             -f $param
 
-        Addmember
+        Addmember -ReadOnly:$readOnly -WriteOnly:$writeOnly
     }
 }
 
@@ -97,6 +97,24 @@ function AddChannelMembers () {
 }
 
 function Addmember {
+    param(
+        [Switch]$readOnly, [Switch]$writeOnly
+    )
+
+    if ($readOnly -and $writeOnly) {
+        throw "AddMember: cannot be both readOnly and writeOnly for '$param'"
+    }
+
+    # Override signatures based on mode
+    if ($readOnly) {
+        $Signatures['Setter'] = "return Write-Warning (`"ERROR: `$(`$this.identifier()).{0} is read only`")" `
+            -f $param
+    }
+    elseif ($writeOnly) {
+        $Signatures['Getter'] = "return Write-Warning (`"ERROR: `$(`$this.identifier()).{0} is write only`")" `
+            -f $param
+    }
+    
     $AddMemberParams = @{
         Name        = $param
         MemberType  = 'ScriptProperty'

--- a/lib/recorder.ps1
+++ b/lib/recorder.ps1
@@ -25,6 +25,7 @@ class Recorder : IRemote {
         AddActionMembers -PARAMS @('replay', 'ff', 'rew')
         AddFloatMembers -PARAMS @('gain')
         AddIntMembers -PARAMS @('prerectime')
+        AddStringMembers -PARAMS @('prefix') -WriteOnly
 
         AddChannelMembers
     }
@@ -114,16 +115,6 @@ class Recorder : IRemote {
             else {
                 "kbps got: $arg, expected one of $opts" | Write-Warning
             }
-        }
-    )
-
-    hidden $_prefix = $($this | Add-Member ScriptProperty 'prefix' `
-        {
-            return Write-Warning ("ERROR: $($this.identifier()).prefix is write only")
-        } `
-        {
-            param([string]$arg)
-            $this._prefix = $this.Setter('prefix', $arg)
         }
     )
 


### PR DESCRIPTION
## What

Meta functions can now take a `-ReadOnly` or `-WriteOnly` switch parameter.

### Changes

- Device properties now added with meta functions
- `Recorder.Prefix` now added with `AddStringMembers`

## Testing/Notes

Pester tests pass for all kinds.
Manual tests pass for all kinds
- `Bus.Device.Asio`

I didn't bother with VBAN properties because the ones that are currently write-only should no longer be so when Voicemeeter x.1.2.x releases.